### PR TITLE
Clean up UDP code more and migrate creds files.

### DIFF
--- a/src/collects/seashell/backend/server.rkt
+++ b/src/collects/seashell/backend/server.rkt
@@ -53,7 +53,7 @@
            (thunk (void))
            (thunk
              (udp-connect! sock ping-host ping-port)
-             (udp-send! sock #"ping")
+             (udp-send sock #"ping")
              (sync-timeout (read-config 'seashell-ping-timeout)
                            (udp-receive!-evt sock (make-bytes 0))))
            (thunk (udp-close! sock)))))


### PR DESCRIPTION
Untested, but this should work better. Be careful about leaking file descriptors; this is what dynamic-wind is for.
