### PR TITLE
fix tab key inserting hard tab instead of spaces

### DIFF
--- a/src/frontend/js/model/project.js
+++ b/src/frontend/js/model/project.js
@@ -924,6 +924,7 @@ function refreshSettings(succ, fail){
     editor.setOption("tabSize", settings["tab_width"]);
     editor.setOption("indentUnit", settings["tab_width"]);
     editor.setOption("theme", settings["text_style"]);
+    editor.addKeyMap({"Tab": "insertSoftTab"});
     // TODO: implement expandtab
 
     // change the options in the Settings menu to the new settings


### PR DESCRIPTION
Style guide says spaces instead of hard tab. I've mentioned in an email but it doesn't seem to have been fixed yet. HTH :) Another option is to bind Tab to indentAuto, as this will mimic DrRacket's behaviour with Tab, but I don't think this is typical editor behavior.