### PR TITLE
get-recent-file: additional argument wasn't reflected in the contract

### DIFF
--- a/src/collects/seashell/backend/files.rkt
+++ b/src/collects/seashell/backend/files.rkt
@@ -264,7 +264,7 @@
 ;;  project - the project to look in
 ;;  subdirectory - the subdirectory to check the default for.
 (define/contract (get-recent-file project subdirectory)
-  (-> path-string? path-string?)
+  (-> path-string? path-string? path-string?)
   (define directory (match subdirectory
                       ["" project]
                       [sub (string-append project "/" sub)]))


### PR DESCRIPTION
This is a very important update as currently seashell is failing right on startup.  This wasn't caught by travis because this error only appears at runtime.