### PR TITLE
Allow for Manual Resize

### DIFF
--- a/src/frontend/css/common.css
+++ b/src/frontend/css/common.css
@@ -342,8 +342,13 @@ div.tooltip .tooltip-inner {
   text-align:right;
 }
 
+#resize-button {
+  display: none;
+}
+
 @media (min-width: 992px) {
-	#console:not(.console-narrow) #console-title {
+	#resize-button { display: inline; }
+  #console:not(.console-narrow) #console-title {
     border: 1px solid #ddd;
 	  border-left: none;
 	}
@@ -351,7 +356,6 @@ div.tooltip .tooltip-inner {
   #console:not(.console-narrow) #console-input { border-left: none }
   #console.console-narrow { width: 100%; }
   #editor.console-narrow { width: 100%; }
-
   #question-controls { text-align: left; }
   #questions-row-container { text-align: left; }
 }

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -856,13 +856,50 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
           runWhenSaved(fn);
         });
         // Resize events
+        //Resize on button click
+        //Variables to keep track of current state
+        self.resizeInit = false;
+        self.manNarrow = false;
+        self.activateResize = function(){
+          if(self.resizeInit === false){
+            self.resizeInit = true;
+            self.manNarrow = false === ($($document).width() < 992);
+          }
+          else {
+            self.manNarrow = !self.manNarrow;
+          }
+          onResize();
+        };
+        //Resize on window size change
         function onResize() {
+          var narrow;
+          if(self.resizeInit === true){
+            narrow = self.manNarrow;
+            //Make sure the borders appear appropriately
+            if(narrow){
+              document.getElementById("console").style.borderLeft = '1px solid #ddd';
+              document.getElementById("console").style.borderTop = 'none';
+            }
+            else {
+              document.getElementById("console").style.borderLeft = 'none';
+              document.getElementById("console").style.borderTop = '1px solid #ddd';
+            }
+          }
+          else{
+             narrow = $($document).width() < 992;
+          }
+          //Adjust width
+          //The 99% is here in order to catch the adition of the border
+          var wc = narrow ? self.resizeInit ? '99%' : '100%' : '50%';
+          var we = narrow ? '100%' : '50%';
+          $('#console').width(wc);
+          $('#editor').width(we);
+          
           var min_height = 500, margin_bottom = 30;
           var min_y_element = $('#editor > .CodeMirror');
           var h = Math.max($($window).height() - (min_y_element.offset().top - $($window).scrollTop()) - margin_bottom,
                            min_height);
-          var narrow = $($document).width() < 992;
-          $('#editor > .CodeMirror')
+                   $('#editor > .CodeMirror')
             .height(Math.floor(narrow ? h * 0.7 : h) - $('#current-file-controls').outerHeight()); 
           $('#console > .CodeMirror')
             .height((narrow ? (h * 0.3 - $('#console-title').outerHeight()) : 1 + h) - $('#console-input').outerHeight());
@@ -944,6 +981,10 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
             extraKeys: {
               "Ctrl-Enter": function() {
                 self.editor.setOption('fullScreen', !self.editor.getOption('fullScreen'));
+              },
+              "Ctrl-Y": function(){
+                self.activateResize(); 
+                console.log("CTRL-Y FUN");
               },
               "Ctrl-I": self.indentAll,
               "Esc": function() {

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -982,10 +982,6 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               "Ctrl-Enter": function() {
                 self.editor.setOption('fullScreen', !self.editor.getOption('fullScreen'));
               },
-              "Ctrl-Y": function(){
-                self.activateResize(); 
-                console.log("CTRL-Y FUN");
-              },
               "Ctrl-I": self.indentAll,
               "Esc": function() {
                 if(self.editor.getOption('fullScreen')) self.editor.setOption('fullScreen', false);

--- a/src/frontend/frontend/templates/project-editor-editview-template.html
+++ b/src/frontend/frontend/templates/project-editor-editview-template.html
@@ -77,6 +77,8 @@
             <div class="console-controls pull-right">
               <button id="console-clear-button"
                       class="btn btn-link console-control">clear</button>
+              <button id="resize-button" ng-click="editFileView.activateResize()"
+                      class="btn btn-link console-control">resize</button>
             </div>
           </div>
           <textarea ui-codemirror ui-codemirror-opts="editFileView.consoleOptions"

--- a/src/frontend/frontend/templates/project-editor-editview-template.html
+++ b/src/frontend/frontend/templates/project-editor-editview-template.html
@@ -84,7 +84,8 @@
           <textarea ui-codemirror ui-codemirror-opts="editFileView.consoleOptions"
             ng-model="editFileView.console.contents" style="margin-top:3px;border-top:1px solid #ddd;"></textarea>
           <div id="console-input">
-            <div class="input-group">
+            <div class="input-group"
+                 style="width: 100%">
               <div class="input-group-addon" style="font-size: 10px">
                 <span class="glyphicon glyphicon-chevron-right"></span>
               </div>


### PR DESCRIPTION
Changes the elements using a new activate Resize function. We can move where the button is but this seemed the most appropriate. 

One more thing that was commented on was that I could add it so we can make the console larger when we resize, but this can cause some weird issues. If you would like that implemented then let me know. For now it still all just remains on one screen-height.