### PR TITLE
Parse address sanitizer output

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -132,15 +132,15 @@
                                               install-path)))
       ;; Location of remote backend
       (cons 'seashell-backend-remote       (let
-                                            ([install-path (build-path seashell-install-path "bin" "seashell-backend-remote")]
-                                             [build-path (build-path SEASHELL_BUILD_PATH "backend/user/seashell-backend-remote")])
+                                            ([install-path (build-path seashell-install-path "bin" "seashell-user-backend")]
+                                             [build-path (build-path SEASHELL_BUILD_PATH "backend/user/seashell-user-backend")])
                                             (if (and SEASHELL_DEBUG (file-exists? build-path))
                                               build-path
                                               install-path)))
       ;; Location of LLVM symbolizer.
       (cons 'llvm-symbolizer               (let
                                             ([install-path (build-path seashell-install-path "bin" "llvm-symbolizer")]
-                                             [build-path (build-path SEASHELL_BUILD_PATH "lib/llvm/bin/seashell-backend-remote")])
+                                             [build-path (build-path SEASHELL_BUILD_PATH "lib/llvm/bin/llvm-symbolizer")])
                                             (if (and SEASHELL_DEBUG (file-exists? build-path))
                                               build-path
                                               install-path)))

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -137,14 +137,14 @@
                                               install-path)))
       ;; Location of remote backend
       (cons 'seashell-backend-remote       (let
-                                            ([install-path (build-path seashell-install-path "bin" "seashell-user-backend")]
+                                            ([install-path (build-path SEASHELL_INSTALL_PATH "bin" "seashell-user-backend")]
                                              [build-path (build-path SEASHELL_BUILD_PATH "backend/user/seashell-user-backend")])
                                             (if (and (not SEASHELL_INSTALLED) (file-exists? build-path))
                                               build-path
                                               install-path)))
       ;; Location of LLVM symbolizer.
       (cons 'llvm-symbolizer               (let
-                                            ([install-path (build-path seashell-install-path "bin" "llvm-symbolizer")]
+                                            ([install-path (build-path SEASHELL_INSTALL_PATH "bin" "llvm-symbolizer")]
                                              [build-path (build-path SEASHELL_BUILD_PATH "lib/llvm/bin/llvm-symbolizer")])
                                             (if (and (not SEASHELL_INSTALLED) (file-exists? build-path))
                                               build-path

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -573,6 +573,11 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
               /0x[0-9a-f]{12}/.exec(asan_contents[1])));
           }
+          else if(/double-free /.test(asan_contents[1])) { // double free
+            self._write(sprintf("%s: Attempting to free address %s, which has already been freed.\n",
+              /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
+              /0x[0-9a-f]{12}/.exec(asan_contents[1])));
+          }
           else { // else print usual message
             _.each(asan_contents, function(line) {
               self._write(line + "\n");

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -568,6 +568,11 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               }
             }
           }
+          else if(/heap-use-after-free /.test(asan_contents[1])) { // use after free
+            self._write(sprintf("%s: Using address %s after it has been freed.\n",
+              /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
+              /0x[0-9a-f]{12}/.exec(asan_contents[1])));
+          }
           else { // else print usual message
             _.each(asan_contents, function(line) {
               self._write(line + "\n");

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -553,6 +553,21 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
               /0x[0-9a-f]{12}/.exec(asan_contents[1])));
           }
+          else if(/LeakSanitizer:/.test(asan_contents[1])) { // memory leak
+            self._write("Memory leaks occurred:\n");
+            for(var idx=3; idx<asan_contents.length; idx++) {
+              if(/^(Direct|Indirect)/.test(asan_contents[idx])) {
+                var last = idx;
+                for(; !/^$/.test(asan_contents[last]); last++);
+                console.log(sprintf("idx: %s, last: %s", idx, last));
+                last--;
+                self._write(sprintf("  %s byte(s) allocated at %s never freed.\n",
+                  /[0-9]+/.exec(asan_contents[idx]),
+                  /\/([^\/]+:[0-9]+)$/.exec(asan_contents[last])[1]));
+                idx = last+1;
+              }
+            }
+          }
           else { // else print usual message
             _.each(asan_contents, function(line) {
               self._write(line + "\n");

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -548,6 +548,11 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
               /0x[0-9a-f]{12}/.exec(asan_contents[1])));
           }
+          else if(/heap-buffer-(over|under)flow /.test(asan_contents[1])) { // heap buffer overflow
+            self._write(sprintf("%s: Heap buffer overflow on address %s. Check indices used for dynamically allocated arrays.\n",
+              /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
+              /0x[0-9a-f]{12}/.exec(asan_contents[1])));
+          }
           else { // else print usual message
             _.each(asan_contents, function(line) {
               self._write(line + "\n");

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -543,6 +543,11 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
               /\/([^\/]+:[0-9]+)$/.exec(asan_contents[2])[1],
               /0x[0-9a-f]{12}/.exec(asan_contents[1])));
           }
+          else if(/stack-buffer-(over|under)flow /.test(asan_contents[1])) { // stack buffer overflow
+            self._write(sprintf("%s: Stack buffer overflow on address %s. Check array indices.\n",
+              /\/([^\/]+:[0-9]+)$/.exec(asan_contents[3])[1],
+              /0x[0-9a-f]{12}/.exec(asan_contents[1])));
+          }
           else { // else print usual message
             _.each(asan_contents, function(line) {
               self._write(line + "\n");

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -538,9 +538,16 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'jque
         self._write(self.stderr);
         self.stdout = self.stderr = "";
         if(self.asan_parse) {
-          _.each(asan_contents, function(line) {
-            self._write(asan_contents.shift() + "\n");
-          });
+          if(/ SEGV /.test(asan_contents[1])) { // segfault
+            self._write(sprintf("%s: Attempt to access invalid address %s.\n",
+              /\/([^\/]+:[0-9]+)$/.exec(asan_contents[2])[1],
+              /0x[0-9a-f]{12}/.exec(asan_contents[1])));
+          }
+          else { // else print usual message
+            _.each(asan_contents, function(line) {
+              self._write(line + "\n");
+            });
+          }
           self.asan_parse = false;
           asan_contents = [];
         }


### PR DESCRIPTION
Here we redirect output from address sanitizer on the frontend to a different queue and process it separately, discarding most of the information and giving simple one-line output to the user.

This may not even be what we want to do long term, but based on feedback from Winter 2015 this should be an improvement from most students' perspective.