### PR TITLE
[compiler] Clang static analyzer

### DIFF
--- a/src/backend/compiler/CMakeLists.txt
+++ b/src/backend/compiler/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(seashell-clang clangFrontend clangFrontendTool clangCodeGe
                               clangSerialization clangDriver
                               clangTooling clangParse clangSema clangAnalysis
                               clangEdit clangAST clangLex clangBasic
+                              clangStaticAnalyzerFrontend
                               ${REQ_LLVM_LIBRARIES})
 add_executable(seashell-test-clang driver.cc)
 target_link_libraries(seashell-test-clang seashell-clang)

--- a/src/backend/compiler/compiler.cc
+++ b/src/backend/compiler/compiler.cc
@@ -57,6 +57,7 @@
 #include <clang/FrontendTool/Utils.h>
 #include <clang/StaticAnalyzer/Frontend/FrontendActions.h>
 #include <clang/Lex/Lexer.h>
+#include <clang/Lex/Preprocessor.h>
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/Triple.h>
@@ -824,12 +825,6 @@ static int compile_module (seashell_compiler* compiler,
     {
       args.push_back(p->c_str());
     }
-    /** Add standard static analyzer options (clang/lib/Driver/Tools.cpp:2954) */
-    args.push_back("-analyzer-store=region");
-    args.push_back("-analyzer-opt-analyze-nested-blocks");
-    args.push_back("-analyzer-eagerly-assume");
-    /** Run all analysis passes. (clang -cc1 -analyzer-checker-help  | awk '{print $1}' | grep -v '^[A-Z]' | awk -F. '{print $1}' | sort | uniq) */
-    args.push_back("-analyzer-checker=alpha,core,cplusplus,deadcode,osx,security,unix");
     args.push_back(src_path);
     
     /** Parse Diagnostic Arguments */

--- a/src/backend/compiler/driver.cc
+++ b/src/backend/compiler/driver.cc
@@ -31,7 +31,7 @@ int main( int argc, char* argv[] ) {
   printf("Build directory: %s.\n", BUILD_DIR);
   printf("Debug build: %d.\n", SEASHELL_DEBUG);
   printf("Is installed: %d.\n", IS_INSTALLED());
-  if (argc > 2) {
+  if (argc > 1) {
     struct seashell_compiler* compiler = seashell_compiler_make();
     seashell_compiler_add_file(compiler, argv[1]);
     seashell_compiler_run(compiler);

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -158,6 +158,18 @@
                                               install-path)))
 
       ;; These flags can be overridden by the configuration file.
+      ;; Default compiler flags.
+      (cons 'compiler-flags               '(;; Warning flags.
+                                            "-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type"
+                                            ;; Compilation flags.
+                                            "-gdwarf-4" "-O0"
+                                            ;; Static Analyzer flags.
+                                            ; Add standard static analyzer options (clang/lib/Driver/Tools.cpp:2954)
+                                            "-analyzer-store=region"
+                                            "-analyzer-opt-analyze-nested-blocks"
+                                            "-analyzer-eagerly-assume"
+                                            ; Run all analysis passes. (clang -cc1 -analyzer-checker-help  | awk '{print $1}' | grep -v '^[A-Z]' | awk -F. '{print $1}' | sort | uniq)
+                                            "-analyzer-checker=alpha,core,cplusplus,deadcode,osx,security,unix"))
       ;; Optional login tracking helper.  (Runs whenever a user logs in.)
       (cons 'login-tracking-helper         #f)
       ;; Enable debug mode execution (corresponds to seashell-numeric-debug value by default)

--- a/src/collects/seashell/backend/project.rkt
+++ b/src/collects/seashell/backend/project.rkt
@@ -373,8 +373,7 @@
     ;; Run the compiler - save the binary to (runtime-files-path) $name-$file-binary
     ;; if everything succeeds.
     (define-values (result messages)
-      (seashell-compile-files/place `("-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type"
-                                      "-gdwarf-4" "-O0"
+      (seashell-compile-files/place `(,@(read-config 'compiler-flags)
                                       ,@(if (directory-exists? project-common) `("-I" ,(some-system-path->string project-common)) '()))
                                     '("-lm") c-files o-files))
     (define output-path (check-and-build-path (runtime-files-path) (format "~a-~a-~a-binary" name (file-name-from-path file) (gensym))))

--- a/src/frontend/frontend/file.js
+++ b/src/frontend/frontend/file.js
@@ -161,7 +161,7 @@ angular.module('frontend-app')
                   found.push({ from: CodeMirror.Pos(line, column),
                                to: CodeMirror.Pos(line),
                                message: message,
-                               severity: 'error' });
+                               severity: error ? 'error' : 'warning' });
               });
               return found;
             });


### PR DESCRIPTION
This PR enables Clang's static analyzer framework for the compiler (available checkers are located at http://clang-analyzer.llvm.org/available_checks.html).

This will hopefully give out better/nicer error messages to students.