### PR TITLE
Fixed .in files >> stdin race condition

### DIFF
--- a/src/collects/seashell/backend/runner.rkt
+++ b/src/collects/seashell/backend/runner.rkt
@@ -69,8 +69,14 @@
   (logf 'debug "Sending ~a bytes to program PID ~a." (bytes-length input) pid)
 
   ;; Send test input to program and wait. 
-  (write-bytes input raw-stdin)
-  (close-output-port raw-stdin)
+  (thread (lambda ()
+    (with-handlers
+      [(exn:fail?
+        (lambda (exn)
+          (logf 'info "write-bytes failed to write ~a.in to program stdin: received error: ~a"
+                      test-name (exn-message exn))))]
+      (write-bytes input raw-stdin))
+    (close-output-port raw-stdin)))
 
   ;; Background read stuff.
   (define-values (buf-stderr cp-stderr) (make-pipe))


### PR DESCRIPTION
With large.in files, and programs that do not read the input and terminate
before write-bytes can finish writing the .in file to the program stdin,
seashell would try to write to the closed stdin port, causing an error.