### PR TITLE
Tune clang and asan

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -170,9 +170,8 @@
                                             ; Add standard static analyzer options (clang/lib/Driver/Tools.cpp:2954)
                                             "-analyzer-store=region"
                                             "-analyzer-opt-analyze-nested-blocks"
-                                            "-analyzer-eagerly-assume"
                                             ; Run all analysis passes. (clang -cc1 -analyzer-checker-help  | awk '{print $1}' | grep -v '^[A-Z]' | awk -F. '{print $1}' | sort | uniq)
-                                            "-analyzer-checker=core,cplusplus,deadcode,osx,unix"))
+                                            "-analyzer-checker=core.CallAndMessage,core.StackAddressEscape,core.UndefinedBinaryOperatorResult,unix"))
       ;; Optional login tracking helper.  (Runs whenever a user logs in.)
       (cons 'login-tracking-helper         #f)
       ;; Enable debug mode execution (corresponds to seashell-numeric-debug value by default)

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -166,12 +166,12 @@
                                             "-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type" "-Werror=import-preprocessor-directive-pedantic"
                                             ;; Compilation flags.
                                             "-gdwarf-4" "-O0" "-mdisable-fp-elim" "-dwarf-column-info"
-                                            ;; Static Analyzer flags.
                                             ; Add standard static analyzer options (clang/lib/Driver/Tools.cpp:2954)
-                                            "-analyzer-store=region"
-                                            "-analyzer-opt-analyze-nested-blocks"
-                                            ; Run all analysis passes. (clang -cc1 -analyzer-checker-help  | awk '{print $1}' | grep -v '^[A-Z]' | awk -F. '{print $1}' | sort | uniq)
-                                            "-analyzer-checker=core.CallAndMessage,core.StackAddressEscape,core.UndefinedBinaryOperatorResult,unix"))
+                                            ;; "-analyzer-store=region"
+                                            ;; "-analyzer-opt-analyze-nested-blocks"
+                                            ; Run analysis passes. (clang -cc1 -analyzer-checker-help  | awk '{print $1}' | grep -v '^[A-Z]' | awk -F. '{print $1}' | sort | uniq)
+                                            ;; "-analyzer-checker=core.CallAndMessage,core.StackAddressEscape,core.UndefinedBinaryOperatorResult,unix"))
+                                            ))
       ;; Optional login tracking helper.  (Runs whenever a user logs in.)
       (cons 'login-tracking-helper         #f)
       ;; Enable debug mode execution (corresponds to seashell-numeric-debug value by default)

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -166,6 +166,8 @@
                                             "-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type" "-Werror=import-preprocessor-directive-pedantic"
                                             ;; Compilation flags.
                                             "-gdwarf-4" "-O0" "-mdisable-fp-elim" "-dwarf-column-info"
+                                            ;; Need this to detect global buffer overflow 
+                                            "-fno-common"
                                             ; Add standard static analyzer options (clang/lib/Driver/Tools.cpp:2954)
                                             ;; "-analyzer-store=region"
                                             ;; "-analyzer-opt-analyze-nested-blocks"


### PR DESCRIPTION
Disable static analysis and common linkage. Fixes #424 and false positives.