### PR TITLE
[build] Update to Racket 6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - g++-4.8
       - ca-certificates
 env:
-  - RACKET_DIR=$HOME/racket RACKET_VERSION=6.1.1 NODE_PATH=/usr/local/lib/node_modules
+  - RACKET_DIR=$HOME/racket RACKET_VERSION=6.3 NODE_PATH=/usr/local/lib/node_modules
 before_install:
   # Get Racket
   - git clone https://github.com/greghendershott/travis-racket.git >/dev/null

--- a/src/collects/seashell/websocket/server.rkt
+++ b/src/collects/seashell/websocket/server.rkt
@@ -18,6 +18,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 (require racket/contract
          racket/unit
+         racket/tcp
          net/tcp-sig
          net/url
          (prefix-in raw: net/tcp-unit)
@@ -28,7 +29,6 @@
          web-server/private/connection-manager
          web-server/private/timer
          racket/async-channel
-         unstable/contract
          seashell/websocket/connection
          seashell/websocket/handshake)
 
@@ -119,7 +119,7 @@
         #:tcp@
         (unit/c (import) (export tcp^))
         #:port
-        tcp-listen-port?
+        listen-port-number?
         #:listen-ip
         (or/c string? false/c)
         #:max-waiting


### PR DESCRIPTION
Before merging this PR, ensure that racket is updated to 6.3 on the build and production environments
as there are some backwards-incompatible changes.