### PR TITLE
Doc cleanup: added youtube video and git reports links to documentation

### DIFF
--- a/src/frontend/frontend/templates/help-template.html
+++ b/src/frontend/frontend/templates/help-template.html
@@ -5,6 +5,8 @@
       <div class="modal-body" id="popup-text">
         <h4>Getting Started</h4>
         See the <a target="_blank" href="docs/user.html">Seashell User Documentation</a>.
+        The <a href="https://www.youtube.com/channel/UC6SqoYX4CAEZSHGDqImzd2Q">CS136 YouTube channel</a>
+        has videos explaining the basics of Seashell and common errors you may encounter.
         <br /><br />
         <h4>Reset Seashell</h4>
         It often helps to reset your Seashell instance if it gets locked
@@ -63,6 +65,11 @@
           Block Unindent.
           </li>
         </ul>
+        <br /><br />
+        <h4>Giving Feedback</h4>
+        Any feedback you may have on Seashell, especially bugs you have encountered, can be reported
+        using <a href="https://gitreports.com/issue/cs136/seashell">Seashell's Git Reports page</a>.
+        Please include your UW userid and full name.
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" ng-click="$close()">Close</button>


### PR DESCRIPTION
On CS136 Piazza the only significant Seashell posts I found were the youtube videos and how to give feedback. So I added a link to the CS136 Youtube channel and a section giving feedback/bug reports to the documentation page.

I wasn't sure how verbose I should be. Since the philosophy is to keep the UI as clean as possible, I didn't want to copy the entire feedback post from Piazza. I also thought about including each youtube video directly with a thumbnail, but that takes up too much space.