### PR TITLE
Fix the problem that test hotkey Control+E displayed as Control+U.

### DIFF
--- a/src/frontend/frontend/templates/project-editor-editview-template.html
+++ b/src/frontend/frontend/templates/project-editor-editview-template.html
@@ -16,7 +16,7 @@
                  style="position: absolute; right: 13px; top: 0px">
               <button id="toolbar-run-tests" ng-click="editFileView.testFile()" class="btn btn-link"
                       ng-disabled="!(editFileView.runnerFile)"
-                      style="padding-left: 0; padding-right: 0; margin-right: 15px; padding-top: 2px" tooltip-placement="left" tooltip="control+U"
+                      style="padding-left: 0; padding-right: 0; margin-right: 15px; padding-top: 2px" tooltip-placement="left" tooltip="Control+E"
                       ng-show="editFileView.console.PIDs === null">
                 <span style="font-size: 18px">test</span>
               </button>


### PR DESCRIPTION
The hotkey was already changed from Control+U to E before.
Don't know why the frontend template wasn't changed.