### PR TITLE
make incompatible pointer types give fatal error

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -165,7 +165,7 @@
       ;; These flags can be overridden by the configuration file.
       ;; Default compiler flags.
       (cons 'compiler-flags               '(;; Warning flags.
-                                            "-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type" "-Werror=import-preprocessor-directive-pedantic"
+                                            "-Wall" "-Werror=int-conversion" "-Werror=int-to-pointer-cast" "-Werror=return-type" "-Werror=import-preprocessor-directive-pedantic" "-Werror=incompatible-pointer-types"
                                             ;; Compilation flags.
                                             "-gdwarf-4" "-O0" "-mdisable-fp-elim" "-dwarf-column-info"
                                             ;; Need this to detect global buffer overflow 


### PR DESCRIPTION
Things like this:

```
float f = 3.14;
int *p = &f;
```

will now give a fatal error and not compile.