### PR TITLE
Make common headers included with <...> tags work in Marmoset

### DIFF
--- a/src/collects/seashell/backend/project.rkt
+++ b/src/collects/seashell/backend/project.rkt
@@ -650,6 +650,7 @@
             
             (copy-from! question-dir)
             (when (directory-exists? common-dir)
+              (copy-directory/files common-dir (check-and-build-path tmpdir "common"))
               (copy-from! common-dir))
             (with-output-to-file
               tmpzip

--- a/src/collects/seashell/backend/project.rkt
+++ b/src/collects/seashell/backend/project.rkt
@@ -650,8 +650,7 @@
             
             (copy-from! question-dir)
             (when (directory-exists? common-dir)
-              (copy-directory/files common-dir (check-and-build-path tmpdir "common"))
-              (copy-from! common-dir))
+              (copy-directory/files common-dir (check-and-build-path tmpdir "common")))
             (with-output-to-file
               tmpzip
               (lambda () (zip->output (pathlist-closure (directory-list))))


### PR DESCRIPTION
This commit makes the student's zip file that's uploaded to Marmoset have the common/ folder. The CS136 ISAs will need to copy the common/ folder to the /tmp/$$.dir folder in their testing script for it to actually work.