### PR TITLE
ASAN allocator can return null

### DIFF
--- a/src/collects/seashell/backend/runner.rkt
+++ b/src/collects/seashell/backend/runner.rkt
@@ -312,7 +312,7 @@
                   ;; Behaviour is inconsistent if we just exec directly.
                   ;; This seems to work.  (why: who knows?)
                   (putenv "ASAN_OPTIONS"
-                          "detect_leaks=1:stack_trace_format=\"{'frame': %n, 'module': '%m', 'offset': '%o', 'function': '%f', 'function_offset': '%q', 'file': '%s', 'line': %l, 'column': %c}\"
+                          "allocator_may_return_null=1:detect_leaks=1:stack_trace_format=\"{'frame': %n, 'module': '%m', 'offset': '%o', 'function': '%f', 'function_offset': '%q', 'file': '%s', 'line': %l, 'column': %c}\"
                             detect_stack_use_after_return=1")
                   (putenv "ASAN_SYMBOLIZER_PATH" (some-system-path->string (read-config 'llvm-symbolizer)))
                   (subprocess #f #f #f binary)]


### PR DESCRIPTION
int *p = malloc(sizeof(int) * 100000000000);

will now make p equal to NULL and ASAN will still give a warning. 