### PR TITLE
[frontend] Refactor websocket-service to wrap websocket_client

### DIFF
--- a/src/frontend/frontend/console.js
+++ b/src/frontend/frontend/console.js
@@ -324,7 +324,7 @@ angular.module('frontend-app')
       self.running = !testing;
       self.PIDs = PIDs;
       _.each(self.PIDs, function (pid) {
-        socket.socket.startIO(project.name, pid);
+        socket.startIO(project.name, pid);
       });
     };
     self.clear = function() {

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -60,7 +60,7 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'ngCo
           confirm("Archive Projects",
             "Are you sure you want to archive all of your projects? If you do this, you will no longer be able to retrieve them through Seashell, but they will be accessible from your student.cs Linux account.")
             .then(function() {
-              $q.when(ws.socket.archiveProjects())
+              $q.when(ws.archiveProjects())
                 .then(function() {
                   // look at all these callbacks
                   $location.path("/");

--- a/src/frontend/frontend/settings.js
+++ b/src/frontend/frontend/settings.js
@@ -51,7 +51,7 @@ angular.module('frontend-app')
         };
 
         self.load = function () {
-          return $q.when(ws.socket.getSettings()).then(function (settings) {
+          return $q.when(ws.getSettings()).then(function (settings) {
             if (settings)
               for (var k in settings)
                 self.settings[k] = settings[k];
@@ -66,7 +66,7 @@ angular.module('frontend-app')
         };
 
         self.save = function () {
-          return $q.when(ws.socket.saveSettings(self.settings)).then(notifyChanges);
+          return $q.when(ws.saveSettings(self.settings)).then(notifyChanges);
         };
 
         self.dialog = function () {

--- a/src/frontend/js/project-service.js
+++ b/src/frontend/js/project-service.js
@@ -95,7 +95,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellFile.prototype.rename = function(name) {
           var self = this;
-          return $q.when(ws.socket.renameFile(self.project.name, self.fullname(), name))
+          return $q.when(ws.renameFile(self.project.name, self.fullname(), name))
             .then(function() {
               var oldname = self.name.join("/");
               self.project.root._removeFromTree(oldname.split("/"), true);
@@ -106,7 +106,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
 
         SeashellFile.prototype.read = function() {
           var self = this;
-          return $q.when(ws.socket.readFile(self.project.name, self.fullname()))
+          return $q.when(ws.readFile(self.project.name, self.fullname()))
             .then(function (conts) {
               return conts;
             });
@@ -120,7 +120,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellFile.prototype.write = function(data) {
           var self = this;
-          return $q.when(ws.socket.writeFile(self.project.name, self.fullname(), data));
+          return $q.when(ws.writeFile(self.project.name, self.fullname(), data));
         };
 
         /**
@@ -162,7 +162,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
             }
             self.children = split[1] || [];
             if (!soft_delete) {
-              return $q.when(ws.socket.deleteFile(self.project.name, split[0][0].fullname()));
+              return $q.when(ws.deleteFile(self.project.name, split[0][0].fullname()));
             }
           }
           else {
@@ -187,12 +187,12 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
           if (path.length == 1) {
             if (!soft_place) {
               if(file.is_dir) {
-                return $q.when(ws.socket.newDirectory(file.project.name,
+                return $q.when(ws.newDirectory(file.project.name,
                   file.fullname())).then(function () {
                   self.children.push(file);
                 });
               } else {
-                return $q.when(ws.socket.newFile(file.project.name,
+                return $q.when(ws.newFile(file.project.name,
                   file.fullname(), contents, encoding, normalize ? true : false))
                     .then(function () {
                       self.children.push(file);
@@ -211,7 +211,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
             } else {
               var dir = new SeashellFile(file.project, file.name.slice(0,file.name.length-path.length+1).join('/'), true);
               return (dir.fullname === "" ? $q.when() : 
-                  $q.when(ws.socket.newDirectory(dir.project.name, dir.fullname())))
+                  $q.when(ws.newDirectory(dir.project.name, dir.fullname())))
                 .then(function() {
                   self.children.push(dir);
                   return self._placeInTree(file, path, soft_place, contents,
@@ -284,15 +284,15 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
 
           var result = null;
           if (lock === "lock") {
-            result = $q.when(ws.socket.lockProject(self.name));
+            result = $q.when(ws.lockProject(self.name));
           } else if (lock === "force-lock") {
-            result = $q.when(ws.socket.forceLockProject(self.name));
+            result = $q.when(ws.forceLockProject(self.name));
           } else {
             result = $q.when();
           }
 
           return result.then(function () {
-            return $q.when(ws.socket.listProject(self.name)).then(function(files) {
+            return $q.when(ws.listProject(self.name)).then(function(files) {
                self.root = new SeashellFile(self, "", true);
                   _.map(files, function(f) {
                    self.root._placeInTree(new SeashellFile(self, f[0], f[1], f[2]), null, true);
@@ -452,7 +452,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
           if (self.lock === "none") {
             return $q.when();
           }
-          return $q.when(ws.socket.unlockProject(self.name));
+          return $q.when(ws.unlockProject(self.name));
         };
 
         /**
@@ -492,7 +492,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.mostRecentlyUsed = function (question) {
           var self = this;
-          return $q.when(ws.socket.getMostRecentlyUsed(self.name, (question && self._getPath(question)) || false))
+          return $q.when(ws.getMostRecentlyUsed(self.name, (question && self._getPath(question)) || false))
             .then(function (recent) {
               if (recent) {
                 if (question && self.hasFile(question, recent.part, recent.file)) {
@@ -521,11 +521,11 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
             var path = self._getPath(question, part, file);
             qpath = self._getPath(question);
 
-            return $q.all([ws.socket.updateMostRecentlyUsed(self.name, false, ["dexists", qpath], question),
-                           ws.socket.updateMostRecentlyUsed(self.name, qpath, ["fexists", path], {part: part, file: file})]);
+            return $q.all([ws.updateMostRecentlyUsed(self.name, false, ["dexists", qpath], question),
+                           ws.updateMostRecentlyUsed(self.name, qpath, ["fexists", path], {part: part, file: file})]);
           } else if (question) {
             qpath = self._getPath(question);
-            return ws.socket.updateMostRecentlyUsed(self.name, false, ["dexists", qpath], question);
+            return ws.updateMostRecentlyUsed(self.name, false, ["dexists", qpath], question);
           }
         };
 
@@ -537,7 +537,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.getFileToRun = function (question) {
             var self = this;
-            return $q.when(ws.socket.getFileToRun(self.name, question))
+            return $q.when(ws.getFileToRun(self.name, question))
                 .then(function (result) {
                     return result;
                 });
@@ -551,7 +551,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.setFileToRun = function (question, folder, file) {
             var self = this;
-            return $q.when(ws.socket.setFileToRun(self.name, question, folder, file));
+            return $q.when(ws.setFileToRun(self.name, question, folder, file));
         };
 
         /**
@@ -562,7 +562,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
         SeashellProject.prototype.remove = function() {
           var self = this;
           return self.close().then(function() {
-            return $q.when(ws.socket.deleteProject(self.name));
+            return $q.when(ws.deleteProject(self.name));
           });
         };
 
@@ -581,7 +581,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
           if (test && tests.length === 0)
             return $q.reject("No tests for question!");
 
-          return $q.when(ws.socket.compileAndRunProject(self.name, question, tests));
+          return $q.when(ws.compileAndRunProject(self.name, question, tests));
         };
 
         /** 
@@ -590,7 +590,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.save = function(message) {
           var self = this;
-          return $q.when(ws.socket.saveProject(self.name, message));
+          return $q.when(ws.saveProject(self.name, message));
         };
 
         /**
@@ -600,7 +600,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.kill = function(pid) {
           var self = this;
-          return $q.when(ws.socket.programKill(pid));
+          return $q.when(ws.programKill(pid));
         };
 
         /**
@@ -610,7 +610,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.getUploadToken = function(question, folder, filename) {
           var self = this;
-          return $q.when(ws.socket.getUploadFileToken(self.name, self._getPath(question, folder, filename)));
+          return $q.when(ws.getUploadFileToken(self.name, self._getPath(question, folder, filename)));
         };
 
         /**
@@ -631,7 +631,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.getDownloadToken = function() {
           var self = this;
-          return $q.when(ws.socket.getExportToken(self.name));
+          return $q.when(ws.getExportToken(self.name));
         };
 
         /**
@@ -720,17 +720,17 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
          */
         SeashellProject.prototype.submit = function(question, project) {
           var self = this;
-          return $q.when(ws.socket.marmosetSubmit(self.name, project, question));
+          return $q.when(ws.marmosetSubmit(self.name, project, question));
         };
 
         SeashellProject.prototype.sendInput = function(pid, message) {
           var self = this;
-          return $q.when(ws.socket.programInput(pid, message));
+          return $q.when(ws.programInput(pid, message));
         };
 
         SeashellProject.prototype.sendEOF = function(pid) {
           var self = this;
-          return $q.when(ws.socket.sendEOF(pid));
+          return $q.when(ws.sendEOF(pid));
         };
     
         
@@ -802,7 +802,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
           return self.missingSkelFiles().then(function(missingFiles) {
               if (missingFiles.length) {
                 return $q.all(missingFiles.map(function(fpath) {
-                    return $q.when(ws.socket.restoreFileFrom(self.name, fpath, self.projectZipURL)).then(function() {
+                    return $q.when(ws.restoreFileFrom(self.name, fpath, self.projectZipURL)).then(function() {
                         // now soft create these files in the front end and read.
                         var file = new SeashellFile(self, fpath, false);
                         return file.read().then(function(contents) {
@@ -824,7 +824,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
        *  to the list of projects available to be opened.
        */
       self.list = function() {
-        return $q.when(ws.socket.getProjects());
+        return $q.when(ws.getProjects());
       };
 
       /* Returns projects listed in PROJ_SKEL_URL
@@ -910,7 +910,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
                   var start = $q.when();
                   return _.foldl(new_projects, function(in_continuation, template) {
                      function clone(failed) {
-                        return $q.when(ws.socket.newProjectFrom(template, 
+                        return $q.when(ws.newProjectFrom(template, 
                            sprintf(PROJ_ZIP_URL_TEMPLATE, template))).then(function () {
                               if (failed) {
                                  return $q.reject("Propagating failure...");
@@ -936,7 +936,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
        * the project is deleted.
        */
       self.delete = function (name) {
-        return $q.when(ws.socket.deleteProject(name));
+        return $q.when(ws.deleteProject(name));
       };
 
       /**
@@ -949,7 +949,7 @@ angular.module('seashell-projects', ['seashell-websocket', 'marmoset-bindings'])
        *  (or a error message on error)
        */
       self.create = function (name, return_project) {
-        return $q.when(ws.socket.newProject(name)).
+        return $q.when(ws.newProject(name)).
           then(function () {
             if (return_project)
               return (new SeashellProject(name)).init();

--- a/src/frontend/js/websocket-service.js
+++ b/src/frontend/js/websocket-service.js
@@ -29,126 +29,336 @@ angular.module('seashell-websocket', ['ngCookies'])
    *    socket                       - Socket object.  Is invalid after disconnect/fail | before connect.
    */
   .service('socket', ['$rootScope', '$q', '$interval', '$cookies', '$timeout',
-      function($scope, $q, $interval, $cookies, $timeout) {
-    "use strict";
-    var self = this;
-    self.socket = null;
-    self.connected = false;
-    self.failed = false;
+    function($scope, $q, $interval, $cookies, $timeout) {
+      "use strict";
+      var self = this;
 
-    var timeout_count = 0;
-    var timeout_interval = null;
-    var key = 0;
-    var callbacks = {};
+       
+      self._socket = null;
+      Object.defineProperty(self, 'socket', {
+        get: function () {
+          throw new ReferenceError("You forgot to replace something.");
+        }
+      });
 
-    /** Registers callbacks to run when the socket has not seen activity
-     *  in some while, and when messages are received after a timeout has passed.
-     */
-    self.register_callback = function(type, cb, now) {
-      callbacks[key] = {type: type, cb: cb, now: now};
+      self.connected = false;
+      self.failed = false;
 
-      if (type === 'disconnected' && !self.connected && now) {
-        $timeout(cb, 0);
-      } else if (type === 'connected' && self.connected && now) {
-        $timeout(cb, 0);
-      } else if (type === 'failed' && self.failed && now) {
-        $timeout(cb, 0);
-      }
-      return key++;
-    };
-    self.unregister_callback = function (key) {
-      delete callbacks[key];
-    };
+      var timeout_count = 0;
+      var timeout_interval = null;
+      var key = 0;
+      var callbacks = {};
 
-    /** Helper function to invoke the I/O callback. */
-    function io_cb(ignored, message) {
-      _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'io';}),
-                   function (x) {return x.cb;}),
-             function (x) {x(message);});
-    }
-    function test_cb(ignored, result) {
-      _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'test';}),
-                   function (x) {return x.cb;}),
-             function (x) {x(result);});
-    }
+      /** Registers callbacks to run when the socket has not seen activity
+       *  in some while, and when messages are received after a timeout has passed.
+       */
+      self.register_callback = function(type, cb, now) {
+        callbacks[key] = {
+          type: type,
+          cb: cb,
+          now: now
+        };
 
-    /** Connects the socket, sets up the disconnection monitor. */ 
-    self.connect = function () {
-      if (!$cookies.get(SEASHELL_CREDS_COOKIE)) {
-        self.failed = true;
-        $timeout(function () {
-          _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'failed';}),
-                       function (x) {return x.cb;}),
-            function (x) {x();});
-        }, 0);
-        return $q.reject("No credentials found!");
-      }
+        if (type === 'disconnected' && !self.connected && now) {
+          $timeout(cb, 0);
+        } else if (type === 'connected' && self.connected && now) {
+          $timeout(cb, 0);
+        } else if (type === 'failed' && self.failed && now) {
+          $timeout(cb, 0);
+        }
+        return key++;
+      };
+      self.unregister_callback = function(key) {
+        delete callbacks[key];
+      };
 
-      try {
-        self.socket = new SeashellWebsocket(sprintf("wss://%s:%d",$cookies.getObject(SEASHELL_CREDS_COOKIE).host, $cookies.getObject(SEASHELL_CREDS_COOKIE).port),
-                                            $cookies.getObject(SEASHELL_CREDS_COOKIE).key,
-                                            /** Failure - probably want to prompt the user to attempt to reconnect/
-                                             *  log in again.
-                                             */
-                                            function () {
-                                              self.failed = true;
-                                              $timeout(function () {
-                                                $interval.cancel(timeout_interval);
-                                                _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'failed';}),
-                                                             function (x) {return x.cb;}),
-                                                  function (x) {x();});
-                                              }, 0);
-                                            },
-                                            /** Socket closed - probably want to prompt the user to reconnect? */
-                                            function () {
-                                              self.connected = false;
-                                              $timeout(function () {
-                                                $interval.cancel(timeout_interval);
-                                                _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'disconnected';}),
-                                                             function (x) {return x.cb;}),
-                                                  function (x) {x();});
-                                              }, 0);
-                                            });
-      } catch (e) {
-        self.failed = true;
-        $timeout(function () {
-          _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'failed';}),
-                       function (x) {return x.cb;}),
-            function (x) {x();});
-        }, 0);
-        return $q.reject(e);
+      /** Helper function to invoke the I/O callback. */
+      function io_cb(ignored, message) {
+        _.each(_.map(_.filter(callbacks, function(x) {
+              return x.type === 'io';
+            }),
+            function(x) {
+              return x.cb;
+            }),
+          function(x) {
+            x(message);
+          });
       }
 
-      return $q.when(self.socket.ready)
-        .then(function () {
-          console.log("Seashell socket set up properly.");
-          timeout_interval = $interval(function () {
-            if (timeout_count++ === 3) {
-              _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'timeout';}),
-                           function (x) {return x.cb;}),
-                function (x) {x();});
-            }
-            $q.when(self.socket.ping())
-              .then(function () {
-                if (timeout_count >= 3) {
-                  _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'timein';}),
-                               function (x) {return x.cb;}),
-                    function (x) {x();});
-                }
-                timeout_count = 0;
+      function test_cb(ignored, result) {
+        _.each(_.map(_.filter(callbacks, function(x) {
+              return x.type === 'test';
+            }),
+            function(x) {
+              return x.cb;
+            }),
+          function(x) {
+            x(result);
+          });
+      }
+
+      /** Connects the socket, sets up the disconnection monitor. */
+      self.connect = function() {
+        if (!$cookies.get(SEASHELL_CREDS_COOKIE)) {
+          self.failed = true;
+          $timeout(function() {
+            _.each(_.map(_.filter(callbacks, function(x) {
+                  return x.type === 'failed';
+                }),
+                function(x) {
+                  return x.cb;
+                }),
+              function(x) {
+                x();
               });
-          }, 4000);
-          self.connected = true;
-          self.failed = false;
-          self.socket.requests[-3].callback = io_cb;
-          self.socket.requests[-4].callback = test_cb;
-          console.log("Websocket disconnection monitor set up properly.");
-          /** Run the callbacks. */
-          _.each(_.map(_.filter(callbacks, function (x) {return x.type === 'connected';}),
-                       function (x) {
-                         return x.cb;
-                       }),
-            function (x) {x();});
-        });
-    };
-  }]);
+          }, 0);
+          return $q.reject("No credentials found!");
+        }
+
+        try {
+          self._socket = new SeashellWebsocket(sprintf("wss://%s:%d", $cookies.getObject(SEASHELL_CREDS_COOKIE).host, $cookies.getObject(SEASHELL_CREDS_COOKIE).port),
+            $cookies.getObject(SEASHELL_CREDS_COOKIE).key,
+            /** Failure - probably want to prompt the user to attempt to reconnect/
+             *  log in again.
+             */
+            function() {
+              self.failed = true;
+              $timeout(function() {
+                $interval.cancel(timeout_interval);
+                _.each(_.map(_.filter(callbacks, function(x) {
+                      return x.type === 'failed';
+                    }),
+                    function(x) {
+                      return x.cb;
+                    }),
+                  function(x) {
+                    x();
+                  });
+              }, 0);
+            },
+            /** Socket closed - probably want to prompt the user to reconnect? */
+            function() {
+              self.connected = false;
+              $timeout(function() {
+                $interval.cancel(timeout_interval);
+                _.each(_.map(_.filter(callbacks, function(x) {
+                      return x.type === 'disconnected';
+                    }),
+                    function(x) {
+                      return x.cb;
+                    }),
+                  function(x) {
+                    x();
+                  });
+              }, 0);
+            });
+        } catch (e) {
+          self.failed = true;
+          $timeout(function() {
+            _.each(_.map(_.filter(callbacks, function(x) {
+                  return x.type === 'failed';
+                }),
+                function(x) {
+                  return x.cb;
+                }),
+              function(x) {
+                x();
+              });
+          }, 0);
+          return $q.reject(e);
+        }
+
+        return $q.when(self._socket.ready)
+          .then(function() {
+            console.log("Seashell socket set up properly.");
+            timeout_interval = $interval(function() {
+              if (timeout_count++ === 3) {
+                _.each(_.map(_.filter(callbacks, function(x) {
+                      return x.type === 'timeout';
+                    }),
+                    function(x) {
+                      return x.cb;
+                    }),
+                  function(x) {
+                    x();
+                  });
+              }
+              $q.when(self._socket.ping())
+                .then(function() {
+                  if (timeout_count >= 3) {
+                    _.each(_.map(_.filter(callbacks, function(x) {
+                          return x.type === 'timein';
+                        }),
+                        function(x) {
+                          return x.cb;
+                        }),
+                      function(x) {
+                        x();
+                      });
+                  }
+                  timeout_count = 0;
+                });
+            }, 4000);
+            self.connected = true;
+            self.failed = false;
+            self._socket.requests[-3].callback = io_cb;
+            self._socket.requests[-4].callback = test_cb;
+            console.log("Websocket disconnection monitor set up properly.");
+            /** Run the callbacks. */
+            _.each(_.map(_.filter(callbacks, function(x) {
+                  return x.type === 'connected';
+                }),
+                function(x) {
+                  return x.cb;
+                }),
+              function(x) {
+                x();
+              });
+          });
+      };
+
+
+      /** The following functions are wrappers around sendMessage.
+       *  Consult dispatch.rkt for a full list of functions.
+       *  These functions take in arguments as specified in server.rkt
+       *  and return a JQuery Deferred object. */
+      self.ping = function(deferred) {
+        return self._socket.ping(deferred);
+      };
+
+      self.compileAndRunProject = function(project, question, test, deferred) {
+        return self._socket.compileAndRunProject(project, question, test, deferred);
+      };
+
+      self.programKill = function(pid, deferred) {
+        return self._socket.programKill(pid, deferred);
+      };
+
+      self.sendEOF = function(pid, deferred) {
+        return self._socket.sendEOF(pid, deferred);
+      };
+
+      self.compileProject = function(project, file, deferred) {
+        return self._socket.compileProject(project, file, deferred);
+      };
+
+      self.saveProject = function(project, message, deferred) {
+        return self._socket.saveProject(project, message, deferred);
+      };
+
+      self.getProjects = function(deferred) {
+        return self._socket.getProjects(deferred);
+      };
+
+      self.listProject = function(name, deferred) {
+        return self._socket.listProject(name, deferred);
+      };
+
+      self.newProject = function(name, deferred) {
+        return self._socket.newProject(name, deferred);
+      };
+
+      self.newProjectFrom = function(name, src_url, deferred) {
+        return self._socket.newProjectFrom(name, src_url, deferred);
+      };
+
+      self.deleteProject = function(name, deferred) {
+        return self._socket.deleteProject(name, deferred);
+      };
+
+      self.lockProject = function(name, deferred) {
+        return self._socket.lockProject(name, deferred);
+      };
+
+      self.forceLockProject = function(name, deferred) {
+        return self._socket.forceLockProject(name, deferred);
+      };
+
+      self.unlockProject = function(name, deferred) {
+        return self._socket.unlockProject(name, deferred);
+      };
+
+      self.readFile = function(name, file_name, deferred) {
+        return self._socket.readFile(name, file_name, deferred);
+      };
+
+      self.newFile = function(name, file_name, contents,
+        encoding, normalize, deferred) {
+        return self._socket.newFile(name, file_name, contents,
+          encoding, normalize, deferred);
+      };
+
+      self.restoreFileFrom = function(projectName, fpath, url) {
+        return self._socket.restoreFileFrom(projectName, fpath, url);
+      };
+
+
+      self.newDirectory = function(name, dir_name, deferred) {
+        return self._socket.newDirectory(name, dir_name, deferred);
+      };
+
+      self.writeFile = function(name, file_name, file_content, deferred) {
+        return self._socket.writeFile(name, file_name, file_content, deferred);
+      };
+
+      self.deleteFile = function(name, file_name, deferred) {
+        return self._socket.deleteFile(name, file_name, deferred);
+      };
+
+      self.deleteDirectory = function(name, dir_name, deferred) {
+        return self._socket.deleteDirectory(name, dir_name, deferred);
+      };
+
+      self.programInput = function(pid, contents, deferred) {
+        return self._socket.programInput(pid, contents, deferred);
+      };
+
+      self.getExportToken = function(project, deferred) {
+        return self._socket.getExportToken(project, deferred);
+      };
+
+      self.getUploadFileToken = function(project, file, deferred) {
+        return self._socket.getUploadFileToken(project, file, deferred);
+      };
+
+      self.renameFile = function(project, oldName, newName, deferred) {
+        return self._socket.renameFile(project, oldName, newName, deferred);
+      };
+
+      self.getMostRecentlyUsed = function(project, directory, deferred) {
+        return self._socket.getMostRecentlyUsed(project, directory, deferred);
+      };
+
+      self.updateMostRecentlyUsed = function(project, directory, predicate, data, deferred) {
+        return self._socket.updateMostRecentlyUsed(project, directory, predicate, data, deferred);
+      };
+
+      self.saveSettings = function(settings, deferred) {
+        return self._socket.saveSettings(settings, deferred);
+      };
+
+      self.getSettings = function(deferred) {
+        return self._socket.getSettings(deferred);
+      };
+
+      self.marmosetSubmit = function(project, assn, subdir, deferred) {
+        return self._socket.marmosetSubmit(project, assn, subdir, deferred);
+      };
+
+      self.startIO = function(project, pid, deferred) {
+        return self._socket.startIO(project, pid, deferred);
+      };
+
+      self.archiveProjects = function(deferred) {
+        return self._socket.archiveProjects(deferred);
+      };
+
+      self.getFileToRun = function(project, question, deferred) {
+        return self._socket.getFileToRun(project, question, deferred);
+      };
+
+      self.setFileToRun = function(project, question, folder, file, deferred) {
+        return self._socket.setFileToRun(project, question, folder, file, deferred);
+      };
+    }
+  ]);


### PR DESCRIPTION
websocket-service now wraps almost all functions in websocket_client.
All usages of ws.socket.fn() have been replaced with ws.fn(), although
debug code is still present in case I missed one.

Conflicts:
	src/frontend/js/project-service.js