### PR TITLE
seashell-config.rkt.in: fix cast a path to String

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -295,7 +295,8 @@
   (: read-config-string (-> Symbol String))
   (define (read-config-string symbol)
     (define result (read-config symbol))
-    (cast result String))
+    (cond [(path? result) (path->string result)]
+          [else (cast result String)]))
   (: read-config-strings (-> Symbol (Listof String)))
   (define (read-config-strings symbol)
     (define result (read-config symbol))


### PR DESCRIPTION
quick fix 