### PR TITLE
Make files readonly if they contain a magic 'readonly' string

### DIFF
--- a/src/frontend/frontend/file.js
+++ b/src/frontend/frontend/file.js
@@ -18,6 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+var SEASHELL_READONLY_STRING = "SEASHELL_READONLY";
+
 /* jshint supernew: true */
 angular.module('frontend-app')
   .controller('EditFileController', ['$state', '$scope', '$timeout', '$q', 'openProject', 'openQuestion',
@@ -577,9 +579,9 @@ angular.module('frontend-app')
         self.project.openFile(self.question, self.folder, self.file)
           .then(function(conts) {
             self.contents = conts.data;
-            if((self.ext === 'rkt' && /\s*;;\s*THIS FILE IS READONLY/i.test(self.contents)) || // racket files
-               ((self.ext === 'c' || self.ext === 'h') && /\s*\/\/\s*THIS FILE IS READONLY/i.test(self.contents))  || // c files
-               ((self.ext === undefined || self.ext === 'txt') && /\s*THIS FILE IS READONLY/i.test(self.contents))) // plaintext files
+            if((self.ext === 'rkt' && RegExp("\\s*;;\\s*"+SEASHELL_READONLY_STRING).test(self.contents)) || // racket files
+               ((self.ext === 'c' || self.ext === 'h') && RegExp("\\s*\/\/\\s*"+SEASHELL_READONLY_STRING).test(self.contents))  || // c files
+               ((self.ext === undefined || self.ext === 'txt') && RegExp("\\s*"+SEASHELL_READONLY_STRING).test(self.contents))) // plaintext files
             {
                 self.fileReadOnly = true;
             }

--- a/src/frontend/frontend/file.js
+++ b/src/frontend/frontend/file.js
@@ -53,6 +53,7 @@ angular.module('frontend-app')
         self.consoleEditor = null;
         self.consoleOptions = {};
         self.editorReadOnly = true; // We start out read only until contents are loaded.
+        self.fileReadOnly = false;
         /** Callback key when connected.
          *  NOTE: This is slightly sketchy -- however, as
          *  the editor will only be loaded if and only if
@@ -263,7 +264,7 @@ angular.module('frontend-app')
         self.refreshSettings = function () {
           // var theme = settings.settings.theme_style === "light" ? "3024-day" : "3024-night";
           var theme = settings.settings.theme_style === "light" ? "default" : "3024-night";
-          self.editorReadOnly = !self.ready || self.isBinaryFile;
+          self.editorReadOnly = !self.ready || self.isBinaryFile || self.fileReadOnly;
           self.editorOptions = {
             scrollbarStyle: "overlay",
             autofocus: true,
@@ -576,6 +577,12 @@ angular.module('frontend-app')
         self.project.openFile(self.question, self.folder, self.file)
           .then(function(conts) {
             self.contents = conts.data;
+            if((self.ext === 'rkt' && /\s*;;\s*THIS FILE IS READONLY/i.test(self.contents)) || // racket files
+               ((self.ext === 'c' || self.ext === 'h') && /\s*\/\/\s*THIS FILE IS READONLY/i.test(self.contents))  || // c files
+               ((self.ext === undefined || self.ext === 'txt') && /\s*THIS FILE IS READONLY/i.test(self.contents))) // plaintext files
+            {
+                self.fileReadOnly = true;
+            }
             self.ready = true;
             if (conts.data.length === 0) self.loaded = true;
             self.project.updateMostRecentlyUsed(self.question, self.folder, self.file);


### PR DESCRIPTION
You can make files readonly by typing these strings anywhere in the file (case-insensitive):

racket: ;; THIS FILE IS READONLY
c/h: // THIS FILE IS READONLY
no extension or txt: THIS FILE IS READONLY