### PR TITLE
Fixes to ASAN parsing and console output buffering (Important)

### DIFF
--- a/src/collects/seashell-cli.rkt
+++ b/src/collects/seashell-cli.rkt
@@ -43,7 +43,6 @@
   (define plain-asan
     (if (not asan) #f
       (let ([parsed (bytes->jsexpr asan)])
-        (printf "~a~n" (hash-ref parsed 'call_stacks))
         (if (string=? "" (hash-ref parsed 'raw_message))
           #f (hash-ref parsed 'raw_message)))))
   (when stdout

--- a/src/collects/seashell-cli.rkt
+++ b/src/collects/seashell-cli.rkt
@@ -43,6 +43,7 @@
   (define plain-asan
     (if (not asan) #f
       (let ([parsed (bytes->jsexpr asan)])
+        (printf "~a~n" (hash-ref parsed 'call_stacks))
         (if (string=? "" (hash-ref parsed 'raw_message))
           #f (hash-ref parsed 'raw_message)))))
   (when stdout

--- a/src/collects/seashell/backend/asan-error-parse.rkt
+++ b/src/collects/seashell/backend/asan-error-parse.rkt
@@ -54,6 +54,9 @@
 ;; A SectionParser also consumes the other arguments of asan-parser (error-type,
 ;; call-stacks, and extra-info) if you need to access that information.
 ;;
+;; A SectionParser also consumes the path where the source files for the program
+;; are stored to filter out stack frames coming from libraries, etc.
+;;
 ;; A SectionParser returns a SectionData which contains data of the parsed section.
 ;; Each field in a SectionData can be #f, to indicate that the parsed section
 ;; doesn't change that field.
@@ -72,13 +75,13 @@
 ;;  * lines-left: A list of the lines that still have to be parsed after this
 ;;                section was parsed.
 ;;
-(define-type SectionParser ((Listof String) String JSList JSHash -> SectionData))
+(define-type SectionParser ((Listof String) String JSList JSHash Path-String -> SectionData))
 (define-type ParserList (Listof SectionParser))
 (struct SectionData ([error-type : (U False String)]
                      [call-stack : (U False JSHash)]
                      [extra-info : (U False JSHash)]
                      [lines-left : (U False (Listof String))]))
-(define no-data (SectionData #f #f #f #f)) 
+(define no-data (SectionData #f #f #f #f))
 
 
 ;; Convenience function that creates a SectionParser that checks if the
@@ -86,7 +89,7 @@
 ;; with the type set to new-type.
 (: match-type (PRegexp String -> SectionParser))
 (define (match-type pattern new-type)
-  (lambda ([lines : (Listof String)] [error-type : String] [call-stacks : JSList] [extra-info : JSHash])
+  (lambda ([lines : (Listof String)] [error-type : String] [call-stacks : JSList] [extra-info : JSHash] [source-dir : Path-String])
     (if (and (cons? lines) (regexp-match pattern (first lines)))
         (SectionData new-type #f #f (rest lines))
         no-data)))
@@ -94,11 +97,11 @@
 ;; Another convenience function for creating SectionParsers. If the first line
 ;; matches pattern, then process-match-result function will be called with
 ;; the ASAN output (lines) and the match result.
-(: match-and-process (PRegexp (String (Listof String) (Listof (U False String)) -> SectionData) -> SectionParser))
+(: match-and-process (PRegexp (String (Listof String) Path-String (Listof (U False String)) -> SectionData) -> SectionParser))
 (define (match-and-process pattern process-match-result)
-  (lambda ([lines : (Listof String)] [error-type : String] [call-stacks : JSList] [extra-info : JSHash])
+  (lambda ([lines : (Listof String)] [error-type : String] [call-stacks : JSList] [extra-info : JSHash] [source-dir : Path-String])
     (define match-result (regexp-match pattern (first lines)))
-    (if match-result (process-match-result error-type lines match-result) no-data)))
+    (if match-result (process-match-result error-type lines source-dir match-result) no-data)))
 
 ;; Tries to parse a segfault section. Begins with segfault message then lists
 ;; a stack trace. No extra information is given but the stack trace on its own
@@ -106,8 +109,8 @@
 (define segfault-parser : SectionParser
   (match-and-process
     #px"^=+\\d+=+ERROR: AddressSanitizer: SEGV( on unknown address 0x0+ )?"
-    (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
-      (define-values (framelist lines-left) (try-parse-stack-frame lines))
+    (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
+      (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
       (SectionData (if (second match-result) "segmentation-fault-on-null-address"
                                              "segmentation-fault")
                    (jsexpr `((framelist ,framelist) (misc ,(hash))))
@@ -119,11 +122,11 @@
 (define memory-leak-parser : SectionParser
   (match-and-process
    #px"^[[:alpha:]]+ leak of (\\d+) byte\\(s\\) in (\\d+) object\\(s\\) allocated from:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define mres (cast match-result (Listof String)))
      (define extra-info (jsexpr `((leak_size_in_bytes ,(second mres))
                                   (leak_objects_count ,(third mres)))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -134,12 +137,12 @@
 (define stack-overflow-parser : SectionParser
   (match-and-process
    #px"^[[:alpha:]]+ of size (\\d+) at (0x[[:xdigit:]]+) thread T"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define mres (cast match-result (Listof String)))
      (define extra-info (jsexpr `((description_of_this_framelist "Location of bad memory access")
                                   (size_of_memory_accessed_in_bytes ,(second mres))
                                   (address_of_memory_accessed ,(third mres)))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -150,11 +153,11 @@
 (define function-info : SectionParser
   (match-and-process
    #px"^Address (0x[[:xdigit:]]+) is located in stack of thread T(\\d+) at offset (\\d+) in frame"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define mres (cast match-result (Listof String)))
      (define extra-info (jsexpr `((address_of_memory_accessed ,(second mres))
                                   (offset_in_frame_of_memory_accessed ,(fourth mres)))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -166,7 +169,7 @@
 (define array-parser : SectionParser
   (match-and-process
    #px"\\[(\\d+), (\\d+)\\) '([[:alnum:]_]*)' <== Memory access at offset (\\d+)"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define mres (cast match-result (Listof String)))
      (define array-lower-bound (string->number (second mres)))
      (define array-upper-bound (string->number (third mres)))
@@ -186,7 +189,7 @@
 (define heap-address-details : SectionParser
   (match-and-process
    #px"(0x[[:xdigit:]]+) (is located (\\d+) bytes (to the left|to the right|inside) of (\\d+)-byte region \\[(0x[[:xdigit:]]+),(0x[[:xdigit:]]+)\\))"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False  String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False  String))])
      (define mres (cast match-result (Listof String)))
      (define extra-info (jsexpr (list (list (string->symbol (string-append "details_of_address_" (second mres)))
                                             (third mres)))))
@@ -196,7 +199,7 @@
 (define global-address-details : SectionParser
   (match-and-process
    #px"(0x[[:xdigit:]]+) (is located (\\d+) bytes (to the left|to the right|inside) of global variable '([[:alnum:]_]+)') defined in '([^:']+):(\\d+):(\\d+)' \\(0x[[:xdigit:]]+\\) of size (\\d+)"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define mres (cast match-result (Listof String)))
      (define address (second mres))
      (define variable-name (sixth mres))
@@ -221,10 +224,10 @@
 (define double-free : SectionParser
   (match-and-process
    #px"^=+\\d+=+ERROR: AddressSanitizer: attempting double-free on (0x[[:xdigit:]]+) in thread"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr `((description_of_this_framelist "Location of second free")
                                   (double_free_at_address ,(second match-result)))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData "double-free" ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -233,9 +236,9 @@
 (define double-free-first-free : SectionParser
   (match-and-process
    #px"freed by thread T\\d+ here:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr '((description_of_this_framelist "Location of a free"))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -244,9 +247,9 @@
 (define allocation-details : SectionParser
   (match-and-process
    #px"allocated by thread T\\d+ here:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr '((description_of_this_framelist "Location of memory allocation"))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -256,9 +259,9 @@
 (define free-non-malloc : SectionParser
   (match-and-process
    #px"^=+\\d+=+ERROR: AddressSanitizer: attempting free on address which was not malloc\\(\\)-ed: (0x[[:xdigit:]]+) in thread T"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr `((tried_to_free_this_address ,(second match-result)))))
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData "free-non-malloced-address" ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
                   #f ; global extra info
@@ -268,8 +271,8 @@
 (define frame-parse : SectionParser
   (match-and-process
    #px"^\\{\"frame\": "
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
-     (define-values (framelist lines-left) (try-parse-stack-frame lines))
+   (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
+     (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,(hash))))
                   #f ; global extra info
@@ -293,35 +296,36 @@
         frame-parse
         ))
 
-(: try-parsers ((Listof String) String JSList JSHash  ParserList -> SectionData))
-(define (try-parsers lines error-type call-stacks extra-info section-parsers)
+(: try-parsers ((Listof String) String JSList JSHash Path-String ParserList -> SectionData))
+(define (try-parsers lines error-type call-stacks extra-info source-dir section-parsers)
   (cond [(or (empty? lines) (empty? section-parsers)) no-data]
-        [else (define result ((first section-parsers) lines error-type call-stacks extra-info))
+        [else (define result ((first section-parsers) lines error-type call-stacks extra-info source-dir))
               (if (equal? result no-data)
-                  (try-parsers lines error-type call-stacks extra-info (rest section-parsers))
+                  (try-parsers lines error-type call-stacks extra-info source-dir (rest section-parsers))
                   result)]))
 
 ;; Purpose: Consumes a string raw-asan-output which is the raw output from ASAN. Will parse raw-asan-output, stripping
 ;; out "scary" stuff that students don't care about, and putting important information in a JSON format for the front-end.
 ;; This function is mostly just a wrapper that converts the input into a list of strings, passes it to asan-parser,
 ;; which does most of the work.
-(: asan->json (Bytes -> Bytes))
-(define (asan->json raw-asan-output)
+(: asan->json (Bytes Path-String -> Bytes))
+(define (asan->json raw-asan-output source-dir)
   (define raw-asan-output-str (bytes->string/utf-8 raw-asan-output))
   (string->bytes/utf-8
    (jsexpr->string
     (jsexpr-add (asan-parser (regexp-split #px"\n\\s*" raw-asan-output-str)
-                             "unknown" empty (hash))
+                             "unknown" empty (hash) source-dir)
                 'raw_message raw-asan-output-str))))
 
-(: asan-parser ((Listof String) String JSList JSHash -> JSHash))
-(define (asan-parser lines error-type call-stacks extra-info)
+(: asan-parser ((Listof String) String JSList JSHash Path-String -> JSHash))
+(define (asan-parser lines error-type call-stacks extra-info source-dir)
   (cond [(empty? lines)
          (hash 'error_type error-type
                'call_stacks call-stacks
                'misc extra-info)]
         [else ;; Use the functions in all-parsers to try and parse the first several lines
-         (define section-result : SectionData (try-parsers lines error-type call-stacks extra-info all-parsers))
+         (define section-result : SectionData
+           (try-parsers lines error-type call-stacks extra-info source-dir all-parsers))
          (define new-lines-left (SectionData-lines-left section-result))
          (define new-error-type (SectionData-error-type section-result))
          (define new-call-stack (SectionData-call-stack section-result))
@@ -329,7 +333,8 @@
          (asan-parser (if new-lines-left new-lines-left (rest lines))
                       (if new-error-type new-error-type error-type)
                       (if new-call-stack (cons new-call-stack call-stacks) call-stacks)
-                      (if new-extra-info (hash-union new-extra-info extra-info) extra-info))]))
+                      (if new-extra-info (hash-union new-extra-info extra-info) extra-info)
+                      source-dir)]))
 
 
 (: try-parse-stack-line (String -> (U JSHash False)))
@@ -358,15 +363,14 @@
 ;; Tries to extract a list of stack frames
 ;; returns: List of parsed stack frames
 ;;          Unparsed lines from lines
-(: try-parse-stack-frame (->* ((Listof String)) ((Listof JSHash)) (values (Listof JSHash) (Listof String))))
-(define (try-parse-stack-frame lines [frames-list empty])
+(: try-parse-stack-frame (->* ((Listof String) Path-String) ((Listof JSHash)) (values (Listof JSHash) (Listof String))))
+(define (try-parse-stack-frame lines source-dir [frames-list empty])
   (cond [(empty? lines) (values frames-list lines)]
         [else (define result (try-parse-stack-line (first lines)))
               (cond [(and (not result) (cons? frames-list)) (values frames-list lines)]
-                    [(not result) (try-parse-stack-frame (rest lines) frames-list)]
-                    ;; TODO: find a reliable way to filter out those stack frames which come from
-                    ;;  libc_start, standard libraries etc that works in normal Seashell as well
-                    ;;  as seashell-cli
-                    [(string? (jsexpr-ref result 'file))
-                     (try-parse-stack-frame (rest lines) (cons result frames-list))]
-                    [else (try-parse-stack-frame (rest lines) frames-list)])]))
+                    [(not result) (try-parse-stack-frame (rest lines) source-dir frames-list)]
+                    [(let ([filename (jsexpr-ref result 'file)])
+                       (and (string? filename)
+                            (string-prefix? filename (cast source-dir String))))
+                     (try-parse-stack-frame (rest lines) source-dir (cons result frames-list))]
+                    [else (try-parse-stack-frame (rest lines) source-dir frames-list)])]))

--- a/src/collects/seashell/backend/asan-error-parse.rkt
+++ b/src/collects/seashell/backend/asan-error-parse.rkt
@@ -344,14 +344,14 @@
   ;; the line numbers), so be careful with the colons here.
   (define with-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:word:]]+) (.+):(\\d+):(\\d+)$" aline))
   (define no-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:word:]]+) (.+):(\\d+)$" aline))
-  (cond [(cons? with-col-match) ;(>= (length with-col-match) 7))
+  (cond [(cons? with-col-match)
          (jsexpr `((frame ,(second with-col-match))
                    (offset ,(third with-col-match))
                    (function ,(fourth with-col-match))
                    (file ,(fifth with-col-match))
                    (line ,(sixth with-col-match))
                    (column ,(seventh with-col-match))))]
-        [(cons? no-col-match) ;(>= (length no-col-match) 6))
+        [(cons? no-col-match)
          (jsexpr `((frame ,(second no-col-match))
                    (offset ,(third no-col-match))
                    (function ,(fourth no-col-match))

--- a/src/collects/seashell/backend/asan-error-parse.rkt
+++ b/src/collects/seashell/backend/asan-error-parse.rkt
@@ -3,7 +3,7 @@
 (require typed/json)
 (require/typed racket/string [string-prefix? (String String -> Boolean)])
 (require/typed racket/hash [hash-union (JSHash JSHash -> JSHash)])
-(require/typed racket/base [regexp-match (PRegexp String -> (U False (Listof String)))]
+(require/typed racket/base [regexp-match (PRegexp String -> (U False (Listof (U False String))))]
                [string->number (String -> Real)])
 
 (require (submod seashell/seashell-config typed))
@@ -94,20 +94,35 @@
 ;; Another convenience function for creating SectionParsers. If the first line
 ;; matches pattern, then process-match-result function will be called with
 ;; the ASAN output (lines) and the match result.
-(: match-and-process (PRegexp (String (Listof String) (Listof String) -> SectionData) -> SectionParser))
+(: match-and-process (PRegexp (String (Listof String) (Listof (U False String)) -> SectionData) -> SectionParser))
 (define (match-and-process pattern process-match-result)
   (lambda ([lines : (Listof String)] [error-type : String] [call-stacks : JSList] [extra-info : JSHash])
     (define match-result (regexp-match pattern (first lines)))
     (if match-result (process-match-result error-type lines match-result) no-data)))
+
+;; Tries to parse a segfault section. Begins with segfault message then lists
+;; a stack trace. No extra information is given but the stack trace on its own
+;; cannot be grouped properly by the parser without this function.
+(define segfault-parser : SectionParser
+  (match-and-process
+    #px"^=+\\d+=+ERROR: AddressSanitizer: SEGV( on unknown address 0x0+ )?"
+    (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+      (define-values (framelist lines-left) (try-parse-stack-frame lines))
+      (SectionData (if (second match-result) "segmentation-fault-on-null-address"
+                                             "segmentation-fault")
+                   (jsexpr `((framelist ,framelist) (misc ,(hash))))
+                   #f ; global extra info
+                   lines-left))))
 
 ;; Tries to parse a memory-leak section. In ASAN output, a memory leak section
 ;; starts with the regexp pattern below, followed by a frame list.
 (define memory-leak-parser : SectionParser
   (match-and-process
    #px"^[[:alpha:]]+ leak of (\\d+) byte\\(s\\) in (\\d+) object\\(s\\) allocated from:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
-     (define extra-info (jsexpr `((leak_size_in_bytes ,(second match-result))
-                                  (leak_objects_count ,(third match-result)))))
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+     (define mres (cast match-result (Listof String)))
+     (define extra-info (jsexpr `((leak_size_in_bytes ,(second mres))
+                                  (leak_objects_count ,(third mres)))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
@@ -119,10 +134,11 @@
 (define stack-overflow-parser : SectionParser
   (match-and-process
    #px"^[[:alpha:]]+ of size (\\d+) at (0x[[:xdigit:]]+) thread T"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+     (define mres (cast match-result (Listof String)))
      (define extra-info (jsexpr `((description_of_this_framelist "Location of bad memory access")
-                                  (size_of_memory_accessed_in_bytes ,(second match-result))
-                                  (address_of_memory_accessed ,(third match-result)))))
+                                  (size_of_memory_accessed_in_bytes ,(second mres))
+                                  (address_of_memory_accessed ,(third mres)))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
@@ -134,9 +150,10 @@
 (define function-info : SectionParser
   (match-and-process
    #px"^Address (0x[[:xdigit:]]+) is located in stack of thread T(\\d+) at offset (\\d+) in frame"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
-     (define extra-info (jsexpr `((address_of_memory_accessed ,(second match-result))
-                                  (offset_in_frame_of_memory_accessed ,(fourth match-result)))))
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+     (define mres (cast match-result (Listof String)))
+     (define extra-info (jsexpr `((address_of_memory_accessed ,(second mres))
+                                  (offset_in_frame_of_memory_accessed ,(fourth mres)))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,extra-info)))
@@ -149,42 +166,45 @@
 (define array-parser : SectionParser
   (match-and-process
    #px"\\[(\\d+), (\\d+)\\) '([[:alnum:]_]*)' <== Memory access at offset (\\d+)"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
-     (define array-lower-bound (string->number (second match-result)))
-     (define array-upper-bound (string->number (third match-result)))
-     (define access-location (string->number (fifth match-result)))
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+     (define mres (cast match-result (Listof String)))
+     (define array-lower-bound (string->number (second mres)))
+     (define array-upper-bound (string->number (third mres)))
+     (define access-location (string->number (fifth mres)))
      (define extra-info (jsexpr (cons (if (< access-location array-upper-bound)
                                           (list 'underflow_distance_in_bytes_from_start_of_array (number->string (- array-lower-bound access-location)))
                                           (list 'overflow_distance_in_bytes_from_end_of_array (number->string (- access-location array-upper-bound))))
                                       `((array_size_in_bytes ,(number->string (- array-upper-bound array-lower-bound)))
-                                        (array_variable_name ,(fourth match-result))))))
+                                        (array_variable_name ,(fourth mres))))))
      (SectionData (if (and (equal? error-type "stack-buffer-overflow") (< access-location array-upper-bound))
                       "stack-buffer-underflow" #f)
                   #f ; frame list
-                  (if (not (equal? (fourth match-result) "")) extra-info #f)
+                  (if (not (equal? (fourth mres) "")) extra-info #f)
                   #f)))) ; lines left
 
 ;; For bad heap accesses, ASAN sometimes print info about where the heap access occurred
 (define heap-address-details : SectionParser
   (match-and-process
    #px"(0x[[:xdigit:]]+) (is located (\\d+) bytes (to the left|to the right|inside) of (\\d+)-byte region \\[(0x[[:xdigit:]]+),(0x[[:xdigit:]]+)\\))"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
-     (define extra-info (jsexpr (list (list (string->symbol (string-append "details_of_address_" (second match-result)))
-                                            (third match-result)))))
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False  String))])
+     (define mres (cast match-result (Listof String)))
+     (define extra-info (jsexpr (list (list (string->symbol (string-append "details_of_address_" (second mres)))
+                                            (third mres)))))
      (SectionData #f #f extra-info #f))))
 
 ;; Similarly, ASAN prints details of bad memory accesses in the global region
 (define global-address-details : SectionParser
   (match-and-process
    #px"(0x[[:xdigit:]]+) (is located (\\d+) bytes (to the left|to the right|inside) of global variable '([[:alnum:]_]+)') defined in '([^:']+):(\\d+):(\\d+)' \\(0x[[:xdigit:]]+\\) of size (\\d+)"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
-     (define address (second match-result))
-     (define variable-name (sixth match-result))
-     (define file-path-absolute (seventh match-result))
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
+     (define mres (cast match-result (Listof String)))
+     (define address (second mres))
+     (define variable-name (sixth mres))
+     (define file-path-absolute (seventh mres))
      (define file-name (last (string-split file-path-absolute "/")))
-     (define line-nbr (eighth match-result))
-     (define col-nbr (ninth match-result))
-     (define variable-size (tenth match-result))
+     (define line-nbr (eighth mres))
+     (define col-nbr (ninth mres))
+     (define variable-size (tenth mres))
      (define extra-info (jsexpr (list (list (string->symbol (string-append "details_of_address_" address))
                                             (third match-result))
                                       (list (string->symbol (string-append variable-name "_is_defined_in_file")) file-name)
@@ -201,7 +221,7 @@
 (define double-free : SectionParser
   (match-and-process
    #px"^=+\\d+=+ERROR: AddressSanitizer: attempting double-free on (0x[[:xdigit:]]+) in thread"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr `((description_of_this_framelist "Location of second free")
                                   (double_free_at_address ,(second match-result)))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
@@ -213,7 +233,7 @@
 (define double-free-first-free : SectionParser
   (match-and-process
    #px"freed by thread T\\d+ here:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr '((description_of_this_framelist "Location of a free"))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
@@ -224,7 +244,7 @@
 (define allocation-details : SectionParser
   (match-and-process
    #px"allocated by thread T\\d+ here:"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr '((description_of_this_framelist "Location of memory allocation"))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
@@ -236,7 +256,7 @@
 (define free-non-malloc : SectionParser
   (match-and-process
    #px"^=+\\d+=+ERROR: AddressSanitizer: attempting free on address which was not malloc\\(\\)-ed: (0x[[:xdigit:]]+) in thread T"
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
      (define extra-info (jsexpr `((tried_to_free_this_address ,(second match-result)))))
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData "free-non-malloced-address" ; error type
@@ -248,7 +268,7 @@
 (define frame-parse : SectionParser
   (match-and-process
    #px"^\\{\"frame\": "
-   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof String)])
+   (lambda ([error-type : String] [lines : (Listof String)] [match-result : (Listof (U False String))])
      (define-values (framelist lines-left) (try-parse-stack-frame lines))
      (SectionData #f ; error type
                   (jsexpr `((framelist ,framelist) (misc ,(hash))))
@@ -257,15 +277,14 @@
 
 ;; A big list of functions to try and parse the input lines.
 (define all-parsers : ParserList
-  (list (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: SEGV on unknown address 0x0+ " "segmentation-fault-on-null-address")
-        (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: SEGV" "segmentation-fault")
-        (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-buffer-overflow" "stack-buffer-overflow")
+  (list (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-buffer-overflow" "stack-buffer-overflow")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: global-buffer-overflow" "global-buffer-overflow")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: heap-buffer-overflow" "heap-buffer-overflow")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: heap-use-after-free"  "heap-use-after-free")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-use-after-return"  "stack-use-after-return")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-use-after-scope"  "stack-use-after-scope")
         (match-type #px"^=+\\d+=+ERROR: LeakSanitizer: detected memory leaks" "memory-leak")
+        segfault-parser
         memory-leak-parser
         stack-overflow-parser function-info array-parser
         heap-address-details global-address-details
@@ -282,7 +301,6 @@
                   (try-parsers lines error-type call-stacks extra-info (rest section-parsers))
                   result)]))
 
-
 ;; Purpose: Consumes a string raw-asan-output which is the raw output from ASAN. Will parse raw-asan-output, stripping
 ;; out "scary" stuff that students don't care about, and putting important information in a JSON format for the front-end.
 ;; This function is mostly just a wrapper that converts the input into a list of strings, passes it to asan-parser,
@@ -295,7 +313,6 @@
     (jsexpr-add (asan-parser (regexp-split #px"\n\\s*" raw-asan-output-str)
                              "unknown" empty (hash))
                 'raw_message raw-asan-output-str))))
-
 
 (: asan-parser ((Listof String) String JSList JSHash -> JSHash))
 (define (asan-parser lines error-type call-stacks extra-info)
@@ -320,8 +337,8 @@
   ;; The default ASAN stack frame format sometimes do not print the column number
   ;; Also, the file name may have colons in it (and colons are also used to separate the file path from
   ;; the line numbers), so be careful with the colons here.
-  (define with-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:alnum:]_]+) (.+):(\\d+):(\\d+)$" aline))
-  (define no-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:alnum:]_]+) (.+):(\\d+)$" aline))
+  (define with-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:word:]]+) (.+):(\\d+):(\\d+)$" aline))
+  (define no-col-match (regexp-match #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:word:]]+) (.+):(\\d+)$" aline))
   (cond [(and (cons? with-col-match) (>= (length with-col-match) 7))
          (jsexpr `((frame ,(second with-col-match))
                    (offset ,(third with-col-match))

--- a/src/collects/seashell/backend/project.rkt
+++ b/src/collects/seashell/backend/project.rkt
@@ -444,6 +444,7 @@
                         (current-continuation-marks))))
 
   (define project-base (if full-path name (build-project-path name)))
+  (define project-base-str (path->string (path->complete-path project-base)))
   (define project-common (if full-path
     (build-path project-base (read-config 'common-subdirectory))
     (check-and-build-path project-base (read-config 'common-subdirectory))))
@@ -565,7 +566,7 @@
 
   (cond
     [(and result (empty? tests))
-      (define pid (run-program target base lang #f real-test-location))
+      (define pid (run-program target base project-base-str lang #f real-test-location))
       (thread
         (lambda ()
           (sync (program-wait-evt pid))
@@ -576,7 +577,7 @@
     [result
       (define pids (map
                      (lambda (test)
-                       (run-program target base lang test real-test-location))
+                       (run-program target base project-base-str lang test real-test-location))
                      tests))
       (thread
         (lambda ()

--- a/src/collects/seashell/backend/runner.rkt
+++ b/src/collects/seashell/backend/runner.rkt
@@ -26,7 +26,7 @@
                [current-environment-variables (Parameterof Environment-Variable-Set)]
                [environment-variables-copy (-> Environment-Variable-Set Environment-Variable-Set)])
 (require/typed "asan-error-parse.rkt"
-               [asan->json (-> Bytes Bytes)])
+               [asan->json (-> Bytes Path-String Bytes)])
 
 (provide run-program program-stdin program-stdout program-stderr
          program-wait-evt program-kill program-status program-destroy-handle
@@ -40,6 +40,7 @@
                  [handle : Subprocess] [control : (U False Thread)] [exit-status : (U False Exact-Nonnegative-Integer)]
                  [destroyed-semaphore : Semaphore]
                  [_mode : (U 'test 'run)] [custodian : Custodian]
+                 [source-dir : Path-String]
                  [asan : Bytes]) #:transparent #:mutable #:type-name Program)
 (struct exn:program:run exn:fail:user ())
 
@@ -65,7 +66,7 @@
                          raw-stdin raw-stdout raw-stderr
                          handle control exit-status
                          destroyed-semaphore mode custodian
-                         asan)
+                         source-dir asan)
     pgrm)
   (define pid (subprocess-pid handle))
   ;; Close ports we don't use.
@@ -117,7 +118,7 @@
        (close-output-port cp-stderr)
        (close-output-port cp-stdout)
        ;; Read asan error message and convert it to json (stored as Bytes)
-       (set-program-asan! pgrm (asan->json (delete-read-asan pid)))
+       (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
        
        (define stdout (port->bytes buf-stdout))
        (define stderr (port->bytes buf-stderr))
@@ -175,7 +176,7 @@
                          raw-stdin raw-stdout raw-stderr
                          handle control exit-status
                          destroyed-semaphore mode custodian
-                         asan)
+                         source-dir asan)
     pgrm)
   (define pid (subprocess-pid handle))
   (define (close)
@@ -239,7 +240,7 @@
            (port->bytes raw-stderr)))
        (unless (eof-object? read-stderr)
          (write-bytes read-stderr out-stderr))
-       (set-program-asan! pgrm (asan->json (delete-read-asan pid)))
+       (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
        (close)]
       [#f ;; Program timed out (30 seconds pass without any event)
        (logf 'info "Program with PID ~a timed out." pid)
@@ -283,6 +284,7 @@
 ;; Arguments:
 ;;   program   - the filename of the program to be run
 ;;   directory - the directory containing the program
+;;   soruce-dir- the directory containing the program's source files
 ;;   lang      - the language with which to run the program ('C or 'racket)
 ;;   test      - if #f, I/O is done directly with the user. Otherwise, test is
 ;;               a string representing the name of a test to use in tests/.
@@ -299,9 +301,9 @@
 ;;  PID - handle representing the run.  On a test, test results are written
 ;;    to stdout.  On an interactive run, data is forwarded to/from
 ;;    the program.
-(: run-program (->* (Path-String Path-String (U 'C 'racket) (U False String))
+(: run-program (->* (Path-String Path-String Path-String (U 'C 'racket) (U False String))
                     ((U Path-String 'current-directory 'flat 'tree)) Integer))
-(define (run-program binary directory lang test [test-loc 'tree])
+(define (run-program binary directory source-dir lang test [test-loc 'tree])
   (define test-path (cond
                       [(eq? test-loc 'current-directory) (build-path ".")]
                       [(eq? test-loc 'flat) (build-path directory)]
@@ -362,7 +364,7 @@
                                       raw-stdin raw-stdout raw-stderr
                                       handle #f #f destroyed-semaphore
                                       (if test 'test 'run) run-custodian
-                                      #""))
+                                      source-dir #""))
               (define control-thread
                 (thread
                   (lambda ()
@@ -505,7 +507,7 @@
                              raw-stdin raw-stdout raw-stderr
                              handle control exit-status
                              destroyed-semaphore mode custodian
-                             asan)
+                             source-dir asan)
         pgrm)
 
       ;; Note: ports are Racket pipes and therefore GC'd.

--- a/src/frontend/frontend/console.js
+++ b/src/frontend/frontend/console.js
@@ -144,6 +144,7 @@ angular.module('frontend-app')
         self.PIDs = null;
         self.running = false;
       }
+      self.contents = self._contents;
     });
 
     function printExpectedFromDiff(res) {

--- a/src/tests/run-tests.rkt
+++ b/src/tests/run-tests.rkt
@@ -9,7 +9,8 @@
          "tests/crypto.rkt"
          "tests/compiler.rkt"
          "tests/asan-error-parse.rkt"
-         "tests/config.rkt")
+         "tests/config.rkt"
+         "tests/cli.rkt")
 
 (setup-test-environment)
 ;; Run tests
@@ -24,6 +25,7 @@
         project-suite
         crypto-suite
         asan-parser-suite
+        seashell-cli-suite
         ))))
 (teardown-test-environment)
 

--- a/src/tests/tests/asan-error-parse.rkt
+++ b/src/tests/tests/asan-error-parse.rkt
@@ -211,7 +211,7 @@ int main() {
 HERE
 )
       (define json-answer (compile-run-wait student-code))
-      (check-equal? (hash-ref json-answer 'error_type) "segmentation-fault-on-null-address"))
+      (check-true (has-type-and-stack? json-answer "segmentation-fault-on-null-address")))
 
     (test-case "Segmentation Fault Test"
       (define student-code #<<HERE
@@ -223,7 +223,7 @@ int main() {
 HERE
 )
       (define json-answer (compile-run-wait student-code))
-      (check-equal? (hash-ref json-answer 'error_type) "segmentation-fault"))
+      (check-true (has-type-and-stack? json-answer "segmentation-fault")))
 
 ;; ---- NO ERROR TEST ---------------------------
     (test-case "No Error Test"
@@ -250,7 +250,7 @@ int main() {
 HERE
 )
       (define json-answer (compile-run-wait student-code))
-      (check-equal? (hash-ref json-answer 'error_type) "unknown")
+      (check-true (has-type-and-stack? json-answer "unknown" 0))
       (check-equal? (hash-ref json-answer 'raw_message) ""))
 
 ))

--- a/src/tests/tests/asan-error-parse.rkt
+++ b/src/tests/tests/asan-error-parse.rkt
@@ -29,7 +29,6 @@
            (= stacks (length (hash-ref result 'call_stacks)))
            (not (empty? (hash-ref result 'call_stacks))))))
 
-
 (define/provide-test-suite asan-parser-suite
   (test-suite "ASAN Parser Tests"
 

--- a/src/tests/tests/cli.rkt
+++ b/src/tests/tests/cli.rkt
@@ -1,0 +1,62 @@
+#lang racket
+
+(require seashell/seashell-config
+         rackunit)
+
+(define seashell-cli-exe (build-path SEASHELL_BUILD_PATH "src/collects/seashell-cli"))
+
+(define/contract (seashell-cli . params)
+  (->* () #:rest (listof string?) integer?)
+  (apply system*/exit-code (cons seashell-cli-exe params)))
+
+(define/contract (cli-marmtest code in expect [timeout #f])
+  (->* (string? string? string?) ((or/c #f integer?)) integer?)
+  (dynamic-wind
+    (thunk (with-output-to-file "main.c" (thunk (display code)))
+           (with-output-to-file "main.in" (thunk (display in)))
+           (with-output-to-file "main.expect" (thunk (display expect))))
+    (thunk (if timeout
+               (seashell-cli "marmtest" "-t" (number->string timeout) "." "main.c" "main" "out" "err")
+               (seashell-cli "marmtest" "." "main.c" "main" "out" "err")))
+    (thunk (map delete-file '("main.c" "main.in" "main.expect")))))
+
+(define/provide-test-suite seashell-cli-suite
+  #:before (thunk (make-directory (build-path (read-config 'seashell) "cli-files"))
+                  (current-directory (build-path (read-config 'seashell) "cli-files")))
+  #:after (thunk (delete-directory/files (build-path (read-config 'seashell) "cli-files")))
+  (test-suite "seashell-cli test suite"
+    (test-case "A program fails to compile"
+      (check-equal?
+        (cli-marmtest "good code;\n" "" "")
+        10))
+
+    (test-case "A program crashes at runtime"
+      (check-equal?
+        (cli-marmtest "#include <stdio.h>\nint main(){int *p=NULL;printf(\"%d\\n\",*p);}"
+                      "" "")
+        20))
+
+    (test-case "A program fails an assertion"
+      (check-equal?
+        (cli-marmtest "#include <assert.h>\nint main(){assert(0);}"
+                      "" "")
+        21))
+
+    (test-case "A program fails the test"
+      (check-equal?
+        (cli-marmtest "#include <stdio.h>\nint main(){int x;scanf(\"%d\",&x);printf(\"%d\\n\",x);}"
+                      "42\n" "43\n")
+        30))
+
+    (test-case "A program passes the test"
+      (check-equal?
+        (cli-marmtest "#include <stdio.h>\nint main(){int x;scanf(\"%d\",&x);printf(\"%d\\n\",x);}"
+                      "42\n"
+                      "42\n")
+        40))
+
+    (test-case "A program times out"
+      (check-equal?
+        (cli-marmtest "int main(){while(1){}}" "" "" 1)
+        50))
+  ))


### PR DESCRIPTION
- Fix segfault ASAN parsing to give stack trace, line numbers
- Add an additional check to the ASAN parser tests
- Make it possible for ASAN parsing code to work from seashell-cli
- Fix frontend console output buffering so we aren't waiting unnecessarily to display program output
- Add some basic tests for seashell-cli