### PR TITLE
Fix ASAN parser's stack frame regexp match pattern

### DIFF
--- a/src/collects/seashell/backend/asan-driver.rkt
+++ b/src/collects/seashell/backend/asan-driver.rkt
@@ -2,15 +2,17 @@
 
 ;; This driver lets you run the asan-error-parse.rkt file
 ;; directly (ie outside of seashell). This is faster for
-;; development because you do not have to rebuild anything,
-;; just edit asan-error-parse.rkt and run this driver directly
-;; from the terminal with racket.
+;; development because you do not have to rebuild anything.
+;; To use this file, edit asan-error-parse.rkt by commenting out
+;; the (require ...) for seashell-config and run this driver directly
+;; from the terminal with racket, for example:
+;; shell> racket asan-driver.rkt /path/to/asan_output.txt | python -m json.tool
 ;;
 ;; This file has no other use and is not used by Seashell
 ;; backend.
 
 (require/typed "asan-error-parse.rkt"
-               [asan->json (-> Bytes Bytes)])
+               [asan->json (-> Bytes Path-String Bytes)])
 
 (define stderr (current-error-port))
 
@@ -22,4 +24,4 @@
 
 (fprintf stderr "-------------- RESULT -----------------\n")
 
-(printf "~a" (asan->json file-contents))
+(printf "~a" (asan->json file-contents (path->string (build-path (find-system-path 'home-dir) ".seashell"))))

--- a/src/collects/seashell/backend/asan-error-parse.rkt
+++ b/src/collects/seashell/backend/asan-error-parse.rkt
@@ -6,10 +6,8 @@
 (require/typed racket/base [regexp-match (PRegexp String -> (U False (Listof (U False String))))]
                [string->number (String -> Real)])
 
+;; To use the asan-driver.rkt for faster testing, comment out this line.
 (require (submod seashell/seashell-config typed))
-;; use these two lines below instead of the one above to use the driver
-;(: read-config-path (Any -> Path-String))
-;(define (read-config-path x) (build-path (find-system-path 'home-dir) ".seashell"))
 
 (provide asan->json)
 
@@ -270,7 +268,7 @@
 ;; Try to parse a frame
 (define frame-parse : SectionParser
   (match-and-process
-   #px"^\\{\"frame\": "
+   #px"#(\\d+) (0x[[:xdigit:]]+) in ([[:word:]]+) (.+):(\\d+)"
    (lambda ([error-type : String] [lines : (Listof String)] [source-dir : Path-String] [match-result : (Listof (U False String))])
      (define-values (framelist lines-left) (try-parse-stack-frame lines source-dir))
      (SectionData #f ; error type


### PR DESCRIPTION
A couple more changes to go along with https://github.com/cs136/seashell/pull/590

This also fixes the example program

```
#include <stdio.h>

int g = -1;
int a[] = {0, 1, 2};

int main(void) {
  printf("%d\n", a[g]);
}
```