### PR TITLE
Pseudoterminal support in the backend for interactive programs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ sudo: required
 dist: trusty
 cache: ccache
 env:
-  - RACKET_DIR=$HOME/racket RACKET_VERSION=6.4 NODE_PATH=/usr/local/lib/node_modules
+  - NODE_PATH=/usr/local/lib/node_modules
 before_install:
   # Get Racket
-  - git clone https://github.com/greghendershott/travis-racket.git >/dev/null
-  - cat travis-racket/install-racket.sh | bash >/dev/null
+  - sudo apt-add-repository ppa:plt/racket
+  - sudo apt-get update
+  - sudo apt-get install racket
   # Install latest node (ES6)
   - nvm install node
   - nvm use node
@@ -34,7 +35,8 @@ before_install:
 script:
   - mkdir build >/dev/null
   - cd build >/dev/null
-  - ../cmake/bin/cmake -Wno-dev -DCMAKE_C_FLAGS="-Qunused-arguments -fcolor-diagnostics" -DCMAKE_CXX_FLAGS="-Qunused-arguments -fcolor-diagnostics" -DSEASHELL_MZTEXT=$HOME/racket/bin/mztext -DSCRIBBLE=$HOME/racket/bin/scribble -DSEASHELL_RACKET=$HOME/racket/bin/racket -DCMAKE_INSTALL_PREFIX=$HOME/install -DPROCESSOR_COUNT=1 -DLLVM_TARGETS_TO_BUILD=X86 -DTRAVIS_BUILD=1 ..
+  - ../cmake/bin/cmake -Wno-dev -DCMAKE_C_FLAGS="-Qunused-arguments -fcolor-diagnostics" -DCMAKE_CXX_FLAGS="-Qunused-arguments -fcolor-diagnostics"
+    -DCMAKE_INSTALL_PREFIX=$HOME/install -DPROCESSOR_COUNT=1 -DLLVM_TARGETS_TO_BUILD=X86 -DTRAVIS_BUILD=1 ..
   - make -j2
   - CTEST_OUTPUT_ON_FAILURE=true make test
   - ../src/tests/frontend-tests/node_modules/karma/bin/karma start ../src/tests/frontend-tests/seashell.conf.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
   - NODE_PATH=/usr/local/lib/node_modules
 before_install:
   # Get Racket
-  - sudo apt-add-repository ppa:plt/racket
+  - sudo apt-add-repository -y ppa:plt/racket
   - sudo apt-get update
-  - sudo apt-get install racket
+  - sudo apt-get install racket -y
   # Install latest node (ES6)
   - nvm install node
   - nvm use node

--- a/src/collects/CMakeLists.txt
+++ b/src/collects/CMakeLists.txt
@@ -89,7 +89,14 @@ else ()
                              DEPENDS ${seashell_collects} ${CMAKE_CURRENT_SOURCE_DIR}/seashell-config.rkt.in ${CMAKE_SOURCE_DIR}/src/tests/run-tests.rkt
                                      ${CMAKE_CURRENT_BINARY_DIR}/seashell/seashell-config.rkt ${seashell_racket_tests}
                                      seashell-test-racket-compile)
-  add_custom_target(seashell-binary ALL DEPENDS seashell-racket-test)
+  add_custom_command(OUTPUT seashell-cli
+                             COMMAND ${SEASHELL_RACKET} -l- raco/main exe -l -o "${CMAKE_CURRENT_BINARY_DIR}/seashell-cli"
+                             --exf-clear ++exf -l ++exf errortrace ++exf -S ++exf "${CMAKE_CURRENT_BINARY_DIR}" ++exf -U ++exf --
+                             "${CMAKE_CURRENT_BINARY_DIR}/seashell-cli.rkt"
+                             DEPENDS ${seashell_collects} ${CMAKE_CURRENT_SOURCE_DIR}/seashell-config.rkt.in ${CMAKE_CURRENT_SOURCE_DIR}/seashell-cli.rkt
+                                     ${CMAKE_CURRENT_BINARY_DIR}/seashell/seashell-config.rkt
+                                     seashell-racket-compile)
+  add_custom_target(seashell-binary ALL DEPENDS seashell-racket-test seashell-cli)
   # Install step: copy over real programs.  NOTE:  Make sure that the destination of raco distribute agrees with the configuration.
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION ${SEASHELL_COLLECTS}
     FILES_MATCHING

--- a/src/collects/seashell/backend/runner.rkt
+++ b/src/collects/seashell/backend/runner.rkt
@@ -359,6 +359,7 @@
                                                      "-u" binary)]))
                        ;; Keep the slave end of the PTY open, so the I/O code doesn't crash on us.
                        ;; (It's automatically closed when the program terminates)
+                       ;; NOTE: this does not work on FreeBSD -- https://stackoverflow.com/questions/23458160/final-output-on-slave-pty-is-lost-if-it-was-not-closed-in-parent-why
                        (values handle pty
                                (assert (or master:stdout r:stdout))
                                (assert (or master:stdin r:stdin))

--- a/src/collects/seashell/backend/runner.rkt
+++ b/src/collects/seashell/backend/runner.rkt
@@ -18,13 +18,12 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 (require seashell/log
          (submod seashell/seashell-config typed)
-         seashell/diff)
+         seashell/diff
+         seashell/utils/pty)
 (require/typed racket/serialize
                [serialize (-> Any Any)])
 (require/typed racket/base
-               [#:opaque Environment-Variable-Set environment-variables?]
-               [current-environment-variables (Parameterof Environment-Variable-Set)]
-               [environment-variables-copy (-> Environment-Variable-Set Environment-Variable-Set)])
+               [environment-variables-copy (-> Environment-Variables Environment-Variables)])
 (require/typed "asan-error-parse.rkt"
                [asan->json (-> Bytes Path-String Bytes)])
 
@@ -41,7 +40,8 @@
                  [destroyed-semaphore : Semaphore]
                  [_mode : (U 'test 'run)] [custodian : Custodian]
                  [source-dir : Path-String]
-                 [asan : Bytes]) #:transparent #:mutable #:type-name Program)
+                 [asan : Bytes]
+                 [pty : (U False PTY)]) #:transparent #:mutable #:type-name Program)
 (struct exn:program:run exn:fail:user ())
 
 (: program-table (HashTable Integer Program))
@@ -66,8 +66,8 @@
                          raw-stdin raw-stdout raw-stderr
                          handle control exit-status
                          destroyed-semaphore mode custodian
-                         source-dir asan)
-    pgrm)
+                         source-dir asan pty)
+                pgrm)
   (define pid (subprocess-pid handle))
   ;; Close ports we don't use.
   (close-input-port in-stdin)
@@ -75,27 +75,27 @@
 
   (logf 'debug "Sending ~a bytes to program PID ~a." (bytes-length input) pid)
 
-  ;; Send test input to program and wait. 
+  ;; Send test input to program and wait.
   (thread (lambda ()
-    (with-handlers
-      [(exn:fail?
-        (lambda ([exn : exn])
-          (logf 'info "write-bytes failed to write ~a.in to program stdin: received error: ~a"
-                      test-name (exn-message exn))))]
-      (write-bytes input raw-stdin))
-    (close-output-port raw-stdin)))
+            (with-handlers
+             [(exn:fail?
+               (lambda ([exn : exn])
+                 (logf 'info "write-bytes failed to write ~a.in to program stdin: received error: ~a"
+                       test-name (exn-message exn))))]
+             (write-bytes input raw-stdin))
+            (close-output-port raw-stdin)))
 
   ;; Background read stuff.
   (define-values (buf-stderr cp-stderr) (make-pipe))
   (define-values (buf-stdout cp-stdout) (make-pipe))
   (define stderr-thread (thread (lambda ()
-            (logf 'debug "Starting copy port for stderr for program PID ~a." pid)
-            (copy-port raw-stderr cp-stderr))))
+                                  (logf 'debug "Starting copy port for stderr for program PID ~a." pid)
+                                  (copy-port raw-stderr cp-stderr))))
   (define stdout-thread (thread (lambda ()
-            (logf 'debug "Starting copy port for stdout for program PID ~a." pid)
-            (copy-port raw-stdout cp-stdout))))
+                                  (logf 'debug "Starting copy port for stdout for program PID ~a." pid)
+                                  (copy-port raw-stdout cp-stdout))))
 
-  ;; Helper to close ports
+  ;; Helper to close ports (note -- there is no PTY when running a test)
   (define (close)
     (close-input-port raw-stdout)
     (close-input-port raw-stderr)
@@ -108,59 +108,71 @@
     (match (sync/timeout (read-config-nonnegative-real 'program-run-timeout)
                          #{handle :: (Evtof Any)}
                          #{receive-evt :: (Evtof Any)})
-      [(? (lambda ([evt : Any]) (eq? handle evt))) ;; Program quit
-       (logf 'info "Program with PID ~a quit with status ~a." pid (subprocess-status handle))
-       (set-program-exit-status! pgrm (cast (subprocess-status handle) Exact-Nonnegative-Integer))
-       ;; Wait for threads to finish copying
-       (thread-wait stderr-thread)
-       (thread-wait stdout-thread)
-       ;; Read stdout, stderr.
-       (close-output-port cp-stderr)
-       (close-output-port cp-stdout)
-       ;; Read asan error message and convert it to json (stored as Bytes)
-       (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
-       
-       (define stdout (port->bytes buf-stdout))
-       (define stderr (port->bytes buf-stderr))
-       (define asan-output (program-asan pgrm))
+           [(? (lambda ([evt : Any]) (eq? handle evt))) ;; Program quit
+            (logf 'info "Program with PID ~a quit with status ~a." pid (subprocess-status handle))
+            (set-program-exit-status! pgrm (cast (subprocess-status handle) Exact-Nonnegative-Integer))
+            ;; Wait for threads to finish copying
+            (thread-wait stderr-thread)
+            (thread-wait stdout-thread)
+            ;; Read stdout, stderr.
+            (close-output-port cp-stderr)
+            (close-output-port cp-stdout)
+            ;; Read asan error message and convert it to json (stored as Bytes)
+            (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
 
-       (match (subprocess-status handle)
-         [0
-          ;; Three cases:
-          (cond
-            [(not expected)
-             (write (serialize `(,pid ,test-name "no-expect" ,stdout ,stderr ,asan-output)) out-stdout)]
-            [(equal? stdout expected)
-             (write (serialize `(,pid ,test-name "passed" ,stdout ,stderr)) out-stdout)]
-            [else
-              ;; Split expected and output, difference them.
-              (define output-lines (regexp-split #rx"\n" stdout))
-              (define expected-lines (regexp-split #rx"\n" expected))
-              ;; hotfix: diff with empty because it's slow
-              (write (serialize `(,pid ,test-name "failed" ,(list-diff expected-lines '()) ,stderr ,stdout ,asan-output)) out-stdout)])]
-         [_ (write (serialize `(,pid ,test-name "error" ,(subprocess-status handle) ,stderr ,asan-output)) out-stdout)])
-       (logf 'debug "Done sending test results for program PID ~a." pid)
-       (close)]
-      [#f ;; Program timed out ('program-run-timeout seconds pass without any event)
-       (logf 'info "Program with PID ~a timed out after ~a seconds." pid (read-config-nonnegative-real 'program-run-timeout))
-       (set-program-exit-status! pgrm 255)
-       ;; Kill copy-threads before killing program
-       (kill-thread stderr-thread)
-       (kill-thread stdout-thread)
-       (subprocess-kill handle #t)
-       (write (serialize `(,pid ,test-name "timeout")) out-stdout)
-       (close)]
-      [(? (lambda ([evt : Any]) (eq? receive-evt evt))) ;; Received a signal.
-       (match (thread-receive)
-         ['kill
-          (logf 'info "Program with PID ~a killed." pid)
-          (kill-thread stderr-thread)
-          (kill-thread stdout-thread)
-          (set-program-exit-status! pgrm 254)
-          (subprocess-kill handle #t)
-          (write (serialize `(,pid ,test-name "killed")) out-stdout)
-          (close)])]))
+            (define stdout (port->bytes buf-stdout))
+            (define stderr (port->bytes buf-stderr))
+            (define asan-output (program-asan pgrm))
+
+            (match (subprocess-status handle)
+                   [0
+                    ;; Three cases:
+                    (cond
+                     [(not expected)
+                      (write (serialize `(,pid ,test-name "no-expect" ,stdout ,stderr ,asan-output)) out-stdout)]
+                     [(equal? stdout expected)
+                      (write (serialize `(,pid ,test-name "passed" ,stdout ,stderr)) out-stdout)]
+                     [else
+                      ;; Split expected and output, difference them.
+                      (define output-lines (regexp-split #rx"\n" stdout))
+                      (define expected-lines (regexp-split #rx"\n" expected))
+                      ;; hotfix: diff with empty because it's slow
+                      (write (serialize `(,pid ,test-name "failed" ,(list-diff expected-lines '()) ,stderr ,stdout ,asan-output)) out-stdout)])]
+                   [_ (write (serialize `(,pid ,test-name "error" ,(subprocess-status handle) ,stderr ,asan-output)) out-stdout)])
+            (logf 'debug "Done sending test results for program PID ~a." pid)
+            (close)]
+           [#f ;; Program timed out ('program-run-timeout seconds pass without any event)
+            (logf 'info "Program with PID ~a timed out after ~a seconds." pid (read-config-nonnegative-real 'program-run-timeout))
+            (set-program-exit-status! pgrm 255)
+            ;; Kill copy-threads before killing program
+            (kill-thread stderr-thread)
+            (kill-thread stdout-thread)
+            (subprocess-kill handle #t)
+            (write (serialize `(,pid ,test-name "timeout")) out-stdout)
+            (close)]
+           [(? (lambda ([evt : Any]) (eq? receive-evt evt))) ;; Received a signal.
+            (match (thread-receive)
+                   ['kill
+                    (logf 'info "Program with PID ~a killed." pid)
+                    (kill-thread stderr-thread)
+                    (kill-thread stdout-thread)
+                    (set-program-exit-status! pgrm 254)
+                    (subprocess-kill handle #t)
+                    (write (serialize `(,pid ,test-name "killed")) out-stdout)
+                    (close)])]))
   (void))
+
+;; (drain-port in out)
+;; Drains all available bytes from in to out.
+(: drain-port (-> Input-Port Output-Port Any))
+(define (drain-port in out)
+  (let loop ()
+    (define output (make-bytes (read-config-integer 'io-buffer-size)))
+    (define read (read-bytes-avail!* output in))
+    (when (and (number? read) (read . > . 0))
+      (write-bytes output out)
+      (loop))))
+
 
 ;; (program-control-thread program)
 ;; Control thread helper for a running program.
@@ -176,8 +188,8 @@
                          raw-stdin raw-stdout raw-stderr
                          handle control exit-status
                          destroyed-semaphore mode custodian
-                         source-dir asan)
-    pgrm)
+                         source-dir asan pty)
+                pgrm)
   (define pid (subprocess-pid handle))
   (define (close)
     (unless (port-closed? raw-stdout)
@@ -194,6 +206,8 @@
       (close-output-port out-stderr))
     (unless (port-closed? out-stdout)
       (close-output-port out-stdout))
+    (assert (PTY? pty))
+    (close-pty pty)
     (custodian-shutdown-all custodian)
     (void))
 
@@ -202,13 +216,13 @@
   (: check-signals (-> (-> Any) Any))
   (define (check-signals tail)
     (if (sync/timeout 0 (thread-receive-evt))
-       (match (thread-receive)
-         ['kill
-          (logf 'info "Program with PID ~a killed." pid)
-          (set-program-exit-status! pgrm 254)
-          (subprocess-kill handle #t)
-          (close)])
-       (tail)))
+        (match (thread-receive)
+               ['kill
+                (logf 'info "Program with PID ~a killed." pid)
+                (set-program-exit-status! pgrm 254)
+                (subprocess-kill handle #t)
+                (close)])
+      (tail)))
 
   (let loop : Any ()
     (define receive-evt (thread-receive-evt))
@@ -216,66 +230,57 @@
                          handle
                          receive-evt
                          (if (port-closed? in-stdin)
-                           never-evt
+                             never-evt
                            in-stdin)
                          (if (port-closed? raw-stderr)
-                           never-evt
+                             never-evt
                            raw-stderr)
                          (if (port-closed? raw-stdout)
-                           never-evt
+                             never-evt
                            raw-stdout))
-      [(? (lambda (evt) (eq? handle evt))) ;; Program quit
-       (logf 'info "Program with PID ~a quit with status ~a." pid (subprocess-status handle))
-       (set-program-exit-status! pgrm (cast (subprocess-status handle) Exact-Nonnegative-Integer))
-       ;; Flush the ports!
-       (define read-stdout
-         (if (port-closed? raw-stdout)
-           eof
-           (port->bytes raw-stdout)))
-       (unless (eof-object? read-stdout)
-         (write-bytes read-stdout out-stdout))
-       (define read-stderr
-         (if (port-closed? raw-stderr)
-           eof
-           (port->bytes raw-stderr)))
-       (unless (eof-object? read-stderr)
-         (write-bytes read-stderr out-stderr))
-       (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
-       (close)]
-      [#f ;; Program timed out (30 seconds pass without any event)
-       (logf 'info "Program with PID ~a timed out." pid)
-       (set-program-exit-status! pgrm 255)
-       (subprocess-kill handle #t)
-       (close)]
-      [(? (lambda (evt) (eq? receive-evt evt))) ;; Received a signal.
-       (check-signals loop)]
-      [(? (lambda (evt) (eq? in-stdin evt))) ;; Received input from user
-       (define input (make-bytes (read-config-integer 'io-buffer-size)))
-       (define read (read-bytes-avail! input in-stdin))
-       (when (integer? read)
-         (write-bytes input raw-stdin 0 read))
-       (when (eof-object? read)
-         (close-input-port in-stdin)
-         (close-output-port raw-stdin))
-       (check-signals loop)]
-      [(? (lambda (evt) (eq? raw-stdout evt))) ;; Received output from program
-       (define output (make-bytes (read-config-integer 'io-buffer-size)))
-       (define read (read-bytes-avail! output raw-stdout))
-       (when (integer? read)
-         (write-bytes output out-stdout 0 read))
-       (when (eof-object? read)
-         (close-input-port raw-stdout)
-         (close-output-port out-stdout))
-       (check-signals loop)]
-      [(? (lambda (evt) (eq? raw-stderr evt))) ;; Received standard error from program
-       (define output (make-bytes (read-config-integer 'io-buffer-size)))
-       (define read (read-bytes-avail! output raw-stderr))
-       (when (integer? read)
-         (write-bytes output out-stderr 0 read))
-       (when (eof-object? read)
-         (close-input-port raw-stderr)
-         (close-output-port out-stderr))
-       (check-signals loop)]))
+           [(? (lambda (evt) (eq? handle evt))) ;; Program quit
+            (logf 'info "Program with PID ~a quit with status ~a." pid (subprocess-status handle))
+            (set-program-exit-status! pgrm (cast (subprocess-status handle) Exact-Nonnegative-Integer))
+            ;; Flush the ports!
+            (unless (port-closed? raw-stdout) (drain-port raw-stdout out-stdout))
+            (unless (port-closed? raw-stderr) (drain-port raw-stderr out-stderr))
+            (set-program-asan! pgrm (asan->json (delete-read-asan pid) source-dir))
+            (close)]
+           [#f ;; Program timed out (30 seconds pass without any event)
+            (logf 'info "Program with PID ~a timed out." pid)
+            (set-program-exit-status! pgrm 255)
+            (subprocess-kill handle #t)
+            (close)]
+           [(? (lambda (evt) (eq? receive-evt evt))) ;; Received a signal.
+            (check-signals loop)]
+           [(? (lambda (evt) (eq? in-stdin evt))) ;; Received input from user
+            (define input (make-bytes (read-config-integer 'io-buffer-size)))
+            (define read (read-bytes-avail! input in-stdin))
+            (when (integer? read)
+              (write-bytes input raw-stdin 0 read))
+            (when (eof-object? read)
+              (close-input-port in-stdin)
+              ;; Send <eof> (#x4) to the PTY, instead of closing the port.
+              (write-byte #x4 raw-stdin))
+            (check-signals loop)]
+           [(? (lambda (evt) (eq? raw-stdout evt))) ;; Received output from program
+            (define output (make-bytes (read-config-integer 'io-buffer-size)))
+            (define read (read-bytes-avail! output raw-stdout))
+            (when (integer? read)
+              (write-bytes output out-stdout 0 read))
+            (when (eof-object? read)
+              (close-input-port raw-stdout)
+              (close-output-port out-stdout))
+            (check-signals loop)]
+           [(? (lambda (evt) (eq? raw-stderr evt))) ;; Received standard error from program
+            (define output (make-bytes (read-config-integer 'io-buffer-size)))
+            (define read (read-bytes-avail! output raw-stderr))
+            (when (integer? read)
+              (write-bytes output out-stderr 0 read))
+            (when (eof-object? read)
+              (close-input-port raw-stderr)
+              (close-output-port out-stderr))
+            (check-signals loop)]))
   (void))
 
 ;; (run-program binary directory lang test [test-loc 'tree])
@@ -305,93 +310,103 @@
                     ((U Path-String 'current-directory 'flat 'tree)) Integer))
 (define (run-program binary directory source-dir lang test [test-loc 'tree])
   (define test-path (cond
-                      [(eq? test-loc 'current-directory) (build-path ".")]
-                      [(eq? test-loc 'flat) (build-path directory)]
-                      [(eq? test-loc 'tree) (build-path directory (read-config-string 'tests-subdirectory))]
-                      [(path-string? test-loc) test-loc]
-                      [else (error "...unreachable.")]))
+                     [(eq? test-loc 'current-directory) (build-path ".")]
+                     [(eq? test-loc 'flat) (build-path directory)]
+                     [(eq? test-loc 'tree) (build-path directory (read-config-string 'tests-subdirectory))]
+                     [(path-string? test-loc) test-loc]
+                     [else (error "...unreachable.")]))
   (define run-custodian (make-custodian))
-
   (parameterize ([current-custodian run-custodian]
                  [current-subprocess-custodian-mode 'interrupt])
-    (call-with-semaphore
-      program-new-semaphore
-      (lambda ()
-        (with-handlers
-            [(exn:fail:filesystem?
-              (lambda ([exn : exn])
-                (raise (exn:program:run
-                        (format "Could not run binary: Received filesystem error: ~a" (exn-message exn))
-                        (current-continuation-marks)))))]
-          (if test
-            (logf 'info "Running file ~a with language ~a using test ~a" binary lang test)
-            (logf 'info "Running file ~a with language ~a" binary lang))
-
-          (define-values (handle raw-stdout raw-stdin raw-stderr)
-            (parameterize
-              ([current-directory directory]
-               [current-environment-variables (environment-variables-copy (current-environment-variables))])
-              (match lang
-                ['C
-                  ;; Behaviour is inconsistent if we just exec directly.
-                  ;; This seems to work.  (why: who knows?)
-                  (putenv "ASAN_OPTIONS"
-                          "allocator_may_return_null=1:
-                           detect_leaks=1:
-                           log_path='/tmp/seashell-asan':
-                           detect_stack_use_after_return=1")
-                  (putenv "ASAN_SYMBOLIZER_PATH" (some-system-path->string (build-path (read-config-path 'llvm-symbolizer))))
-                  (subprocess #f #f #f binary)]
-                ['racket (subprocess #f #f #f (read-config-path 'racket-interpreter)
-                                     "-t"
-                                      (some-system-path->string (build-path (read-config-path 'seashell-racket-runtime-library)))
-                                     "-u" binary)])))
-
-              ;; Construct the I/O ports.
-              (define (make-io-pipe)
-                (if test (make-pipe) (make-pipe (read-config-integer 'io-buffer-size))))
-
-              (define-values (in-stdout out-stdout) (make-io-pipe))
-              (define-values (in-stdin out-stdin) (make-io-pipe))
-              (define-values (in-stderr out-stderr) (make-io-pipe))
-              ;; Set buffering modes
-              (file-stream-buffer-mode raw-stdin 'none)
-              ;; Construct the destroyed-semaphore
-              (define destroyed-semaphore (make-semaphore 0))
-              ;; Construct the control structure.
-              (define result (program in-stdin in-stdout in-stderr
-                                      out-stdin out-stdout out-stderr
-                                      raw-stdin raw-stdout raw-stderr
-                                      handle #f #f destroyed-semaphore
-                                      (if test 'test 'run) run-custodian
-                                      source-dir #""))
-              (define control-thread
-                (thread
-                  (lambda ()
-                    (if test
-                      (program-control-test-thread result
-                                                   test
-                                                   (file->bytes (build-path test-path (string-append test ".in")))
-                                                   (with-handlers
-                                                     ([exn:fail:filesystem? (lambda (exn) #f)])
-                                                     (file->bytes (build-path test-path (string-append test ".expect")))))
-                      (program-control-thread result)))))
-              (set-program-control! result control-thread)
-              ;; Install it in the hash-table
-              (define pid (subprocess-pid handle))
-              ;; Block if there's still a PID in there.  This is to prevent
-              ;; nasty race-conditions in which a process which is started
-              ;; has the same PID as a process which is just about to be destroyed.
-              (define block-semaphore
                 (call-with-semaphore
-                  program-destroy-semaphore
-                  (lambda ()
-                    (define handle (hash-ref program-table pid #f))
-                    (if handle (program-destroyed-semaphore handle) #f))))
-              (when block-semaphore (sync (semaphore-peek-evt block-semaphore)))
-              (hash-set! program-table pid result)
-              (logf 'info "Binary ~a running as PID ~a." binary pid)
-              pid)))))
+                 program-new-semaphore
+                 (lambda ()
+                   (with-handlers
+                    [(exn:fail:filesystem?
+                      (lambda ([exn : exn])
+                        (raise (exn:program:run
+                                (format "Could not run binary: Received filesystem error: ~a" (exn-message exn))
+                                (current-continuation-marks)))))]
+                    (if test
+                        (logf 'info "Running file ~a with language ~a using test ~a" binary lang test)
+                      (logf 'info "Running file ~a with language ~a" binary lang))
+                    (define-values (handle pty raw-stdout raw-stdin raw-stderr)
+                      (parameterize
+                       ([current-directory directory]
+                        [current-environment-variables (environment-variables-copy (current-environment-variables))])
+                       (define-values (pty slave:stdout slave:stdin master:stdout master:stdin)
+                         (if (not test)
+                             (let* ([pty (make-pty)]
+                                    [slave:stdout (PTY-s-out pty)]
+                                    [slave:stdin (PTY-s-in pty)]
+                                    [master:stdout (PTY-m-in pty)]
+                                    [master:stdin (PTY-m-out pty)])
+                               (values pty slave:stdout slave:stdin master:stdout master:stdin))
+                           (values #f #f #f #f #f)))
+                       (define-values (handle r:stdout r:stdin r:stderr)
+                         (match lang
+                                ['C
+                                 ;; Behaviour is inconsistent if we just exec directly.
+                                 ;; This seems to work.  (why: who knows?)
+                                 (putenv "ASAN_OPTIONS"
+                                         "allocator_may_return_null=1:detect_leaks=1:log_path='/tmp/seashell-asan':detect_stack_use_after_return=1")
+                                 (putenv "ASAN_SYMBOLIZER_PATH" (some-system-path->string (build-path (read-config-path 'llvm-symbolizer))))
+                                 (subprocess slave:stdout slave:stdin #f binary)]
+                                ['racket (subprocess slave:stdout slave:stdin #f
+                                                     (read-config-path 'racket-interpreter)
+                                                     "-t"
+                                                     (some-system-path->string (build-path (read-config-path 'seashell-racket-runtime-library)))
+                                                     "-u" binary)]))
+                       ;; Keep the slave end of the PTY open, so the I/O code doesn't crash on us.
+                       ;; (It's automatically closed when the program terminates)
+                       (values handle pty
+                               (assert (or master:stdout r:stdout))
+                               (assert (or master:stdin r:stdin))
+                               (assert r:stderr))))
+                    ;; Construct the I/O ports.
+                    (define (make-io-pipe)
+                      (if test (make-pipe) (make-pipe (read-config-integer 'io-buffer-size))))
+                    (define-values (in-stdout out-stdout) (make-io-pipe))
+                    (define-values (in-stdin out-stdin) (make-io-pipe))
+                    (define-values (in-stderr out-stderr) (make-io-pipe))
+                    ;; Set buffering modes
+                    (file-stream-buffer-mode raw-stdin 'none)
+                    ;; Construct the destroyed-semaphore
+                    (define destroyed-semaphore (make-semaphore 0))
+                    ;; Construct the control structure.
+                    (define result (program in-stdin in-stdout in-stderr
+                                            out-stdin out-stdout out-stderr
+                                            raw-stdin raw-stdout raw-stderr
+                                            handle #f #f destroyed-semaphore
+                                            (if test 'test 'run) run-custodian
+                                            source-dir #"" pty))
+                    (define control-thread
+                      (thread
+                       (lambda ()
+                         (if test
+                             (program-control-test-thread result
+                                                          test
+                                                          (file->bytes (build-path test-path (string-append test ".in")))
+                                                          (with-handlers
+                                                           ([exn:fail:filesystem? (lambda (exn) #f)])
+                                                           (file->bytes (build-path test-path (string-append test ".expect")))))
+                           (program-control-thread result)))))
+                    (set-program-control! result control-thread)
+                    ;; Install it in the hash-table
+                    (define pid (subprocess-pid handle))
+                    ;; Block if there's still a PID in there.  This is to prevent
+                    ;; nasty race-conditions in which a process which is started
+                    ;; has the same PID as a process which is just about to be destroyed.
+                    (define block-semaphore
+                      (call-with-semaphore
+                       program-destroy-semaphore
+                       (lambda ()
+                         (define handle (hash-ref program-table pid #f))
+                         (if handle (program-destroyed-semaphore handle) #f))))
+                    (when block-semaphore (sync (semaphore-peek-evt block-semaphore)))
+                    (hash-set! program-table pid result)
+                    (logf 'info "Binary ~a running as PID ~a." binary pid)
+                    pid)))))
 
 ;; (program-stdin pid)
 ;; Returns the standard input port for a program
@@ -485,7 +500,7 @@
 ;;  #f if program is not done, exit status otherwise
 (: program-asan-message (-> Integer (U False Bytes)))
 (define (program-asan-message pid)
-  (program-asan (hash-ref program-table pid)))  
+  (program-asan (hash-ref program-table pid)))
 
 ;; (program-destroy-handle pid) -> void?
 ;;
@@ -499,27 +514,27 @@
 (: program-destroy-handle (-> Integer Void))
 (define (program-destroy-handle pid)
   (call-with-semaphore
-    program-destroy-semaphore
-    (lambda ()
-      (define pgrm (hash-ref program-table pid))
-      (match-define (program in-stdin in-stdout in-stderr
-                             out-stdin out-stdout out-stderr
-                             raw-stdin raw-stdout raw-stderr
-                             handle control exit-status
-                             destroyed-semaphore mode custodian
-                             source-dir asan)
-        pgrm)
+   program-destroy-semaphore
+   (lambda ()
+     (define pgrm (hash-ref program-table pid))
+     (match-define (program in-stdin in-stdout in-stderr
+                            out-stdin out-stdout out-stderr
+                            raw-stdin raw-stdout raw-stderr
+                            handle control exit-status
+                            destroyed-semaphore mode custodian
+                            source-dir asan pty)
+                   pgrm)
 
-      ;; Note: ports are Racket pipes and therefore GC'd.
-      ;; We don't need to close them.  (Closing the input port
-      ;; cause a bit of a race condition with the dispatch code.
-      ;; We don't close out-stdout and out-stderr as clients
-      ;; may still be using them.  Note that in-stdout and in-stderr
-      ;; MUST be closed for EOF to be properly sent).
-      (hash-remove! program-table pid)
+     ;; Note: ports are Racket pipes and therefore GC'd.
+     ;; We don't need to close them.  (Closing the input port
+     ;; cause a bit of a race condition with the dispatch code.
+     ;; We don't close out-stdout and out-stderr as clients
+     ;; may still be using them.  Note that in-stdout and in-stderr
+     ;; MUST be closed for EOF to be properly sent).
+     (hash-remove! program-table pid)
 
-      ;; Post the destroyed semaphore
-      (semaphore-post destroyed-semaphore))))
+     ;; Post the destroyed semaphore
+     (semaphore-post destroyed-semaphore))))
 
 ;; Retrieve asan error message at "/tmp/seashell-asan.{pid}"
 ;;  this is set in "run-program"

--- a/src/collects/seashell/utils/pty.rkt
+++ b/src/collects/seashell/utils/pty.rkt
@@ -1,0 +1,140 @@
+#lang typed/racket
+;; Seashell's FFI to PTY functions.
+;; Copyright (C) 2017 The Seashell Maintainers;
+;;   based on pty.rkt from willghatch/rackterm -- Copyright (C) 2015.
+;;   Originally licensed under LGPLv3+.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; See also 'ADDITIONAL TERMS' at the end of the included LICENSE file.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+(module ffi racket/base
+  (require ffi/unsafe
+           ffi/unsafe/define
+           racket/string
+           racket/port
+           racket/system)
+  (provide (all-defined-out))
+
+  (define-ffi-definer define-self (ffi-lib #f))
+  (define-ffi-definer define-pty (ffi-lib "libutil"))
+  (define-cstruct _winsize ([height _ushort]
+                            [width _ushort]
+                            [x _ushort]
+                            [y _ushort]))
+  (define TIOCSWINSZ_gnu #x5414)
+  (define TIOCGWINSZ_gnu #x5413)
+  (define TIOCSCTTY_gnu #x540E)
+  (define TIOCNOTTY_gnu #x5422)
+  (define TIOCSWINSZ_bsd #x80087467)
+  (define TIOCGWINSZ_bsd #x40087468)
+  (define TIOCSCTTY_bsd #x20007461)
+  (define TIOCNOTTY_bsd #x20007471)
+
+  (define os-type (system-type 'os))
+  (define uname-s (if (equal? os-type 'windows)
+                      "windows"
+                      (string-trim (with-output-to-string
+                                     (lambda () (system "uname -s"))))))
+  (define freebsd-ioctls? (or (string-ci=? uname-s "FreeBSD")
+                              (string-ci=? uname-s "Darwin")))
+  ;; ioctl request parameters are ints in Linux, but longs in FreeBSD and MacOSX
+  (define ioctl-req-type (if (or (equal? (system-type 'word) 64)
+                                 freebsd-ioctls?)
+                             _long _int))
+
+  (define TIOCSWINSZ (if freebsd-ioctls? TIOCSWINSZ_bsd TIOCSWINSZ_gnu))
+  (define TIOCGWINSZ (if freebsd-ioctls? TIOCGWINSZ_bsd TIOCGWINSZ_gnu))
+  (define TIOCSCTTY (if freebsd-ioctls? TIOCSCTTY_bsd TIOCSCTTY_gnu))
+  (define TIOCNOTTY (if freebsd-ioctls? TIOCNOTTY_bsd TIOCNOTTY_gnu))
+
+  (define-self scheme_make_fd_output_port
+               (_fun _int _scheme _int _int _int -> _scheme))
+
+  (define (new-winsize [width 80] [height 24])
+    (make-winsize height width 0 0))
+
+  (define (_openpty [width 80] [height 24])
+    (define winsize (new-winsize width height))
+    (define-pty openpty (_fun (amaster : (_ptr o _int))
+                              (aslave : (_ptr o _int))
+                              (name : _pointer)
+                              (termios-ptr : _pointer)
+                              (winsize : (_ptr i _winsize))
+                              -> (r : _int)
+                              -> (if ( < 0 r )
+                                   (error "openpty failed: ~a." r)
+                                   (values amaster aslave))))
+    (define-values (masterfd slavefd) (openpty #f #f winsize))
+    (define-values (m-in m-out) (scheme_make_fd_output_port masterfd (format "<pty-master:~a>" masterfd) 0 0 1))
+    (define-values (s-in s-out) (scheme_make_fd_output_port slavefd (format "<pty-slave:~a>" slavefd) 0 0 1))
+    (values m-in m-out s-in s-out masterfd slavefd))
+
+  (define (_set-pty-size fd width height)
+    (define-pty ioctl (_fun (fd : _int)
+                            (request : ioctl-req-type)
+                            (winsize : (_ptr i _winsize))
+                            -> (r : _int)
+                            -> (if ( < 0 r )
+                                 (error "ioctl (setting PTY size) failed: ~a." r)
+                                 (void))))
+    (ioctl fd TIOCSWINSZ (new-winsize width height)))
+
+  (define (_get-pty-size fd)
+    (define-pty ioctl (_fun (fd : _int)
+                            (request : ioctl-req-type)
+                            (winsize : (_ptr o _winsize))
+                            -> (r : _int)
+                            -> (if ( < 0 r )
+                                 (error "ioctl (setting PTY size) failed: ~a." r)
+                                 winsize)))
+    (define winsize (ioctl fd TIOCGWINSZ))
+    (values (winsize-width winsize) (winsize-height winsize))))
+
+(require/typed (submod "." ffi)
+               [_openpty (->* () (Integer Integer) (Values Input-Port Output-Port Input-Port Output-Port Integer Integer))]
+               [_set-pty-size (-> Integer Integer Integer Any)]
+               [_get-pty-size (-> Integer (Values Integer Integer))])
+(provide (all-defined-out))
+
+(struct PTY ([master : Integer]
+             [slave : Integer]
+             [m-in : Input-Port]
+             [m-out : Output-Port]
+             [s-in : Input-Port]
+             [s-out : Output-Port]
+             [cust : Custodian]) #:transparent)
+
+(: make-pty (->* () (Integer Integer) PTY))
+(define (make-pty [width 80] [height 24])
+  (define cust (make-custodian))
+  (parameterize ([current-custodian cust])
+    (define-values (m-in m-out s-in s-out master slave) (_openpty width height))
+    (PTY master slave m-in m-out s-in s-out cust)))
+
+(: close-pty (-> PTY Any))
+(define (close-pty pty)
+  (custodian-shutdown-all (PTY-cust pty)))
+
+(: close-pty-slave-end (-> PTY Any))
+(define (close-pty-slave-end pty)
+  (unless (port-closed? (PTY-s-in pty)) (close-input-port (PTY-s-in pty))
+  (unless (port-closed? (PTY-s-out pty)) (close-output-port (PTY-s-out pty)))))
+
+(: pty-resize (-> PTY Integer Integer Any))
+(define (pty-resize pty width height)
+  (_set-pty-size (PTY-master pty) width height))
+
+(: pty-getsize (-> PTY (Values Integer Integer)))
+(define (pty-getsize pty)
+  (_get-pty-size (PTY-master pty)))

--- a/src/frontend/frontend/file.js
+++ b/src/frontend/frontend/file.js
@@ -538,7 +538,7 @@ angular.module('frontend-app')
             if(self.console.running) {
               self.project.sendInput(self.console.PIDs[0], self.userInput + "\n");
               self.console.flushForInput();
-              self.console.write(self.userInput + "\n");
+              // self.console.write(self.userInput + "\n"); -- not needed for a TTY
               self.userInput = "";
             }
           }

--- a/src/tests/tests/project.rkt
+++ b/src/tests/tests/project.rkt
@@ -174,15 +174,13 @@ HERE
       (check-true (file-exists? (build-path (build-project-path "test-project-template-file-url") "default/main.c"))))
 
     ;; TODO: Include a test for fetching template via SSH
-#|
-    (test-case "Fetch template from SSH and fail authentication"
+    (test-case "Fetch template from SSH and fail"
       (check-true
         (with-handlers
           ([exn:fail? (thunk* #t)])
             (new-project-from "test-project-template-ssh-fail"
-              "ssh://seashell@ugster25.student.cs.uwaterloo.ca:/home/seashell/template.zip")
+              "ssh://nobody@nonexistant.host:/home/seashell/template.zip")
             #f)))
-|#
 
     (test-case "Fetch template (from file)"
       (new-project-from "test-project-template-file" (format "~a/src/tests/template.zip" SEASHELL_SOURCE_PATH))

--- a/src/tests/tests/project.rkt
+++ b/src/tests/tests/project.rkt
@@ -174,7 +174,7 @@ HERE
       (check-true (file-exists? (build-path (build-project-path "test-project-template-file-url") "default/main.c"))))
 
     ;; TODO: Include a test for fetching template via SSH
-
+#|
     (test-case "Fetch template from SSH and fail authentication"
       (check-true
         (with-handlers
@@ -182,6 +182,7 @@ HERE
             (new-project-from "test-project-template-ssh-fail"
               "ssh://seashell@ugster25.student.cs.uwaterloo.ca:/home/seashell/template.zip")
             #f)))
+|#
 
     (test-case "Fetch template (from file)"
       (new-project-from "test-project-template-file" (format "~a/src/tests/template.zip" SEASHELL_SOURCE_PATH))


### PR DESCRIPTION
This PR replaces the old pipe code used for interactive I/O with code that uses pseudoterminals.
Most of the changes are isolated and small -- the runner now sends Ctrl-D (EOF) instead of closing the write end of the pipe, and the frontend no longer echos the input sent to it (as the TTY does it for us).

This is partial progress towards resolving #444.