### PR TITLE
Updates to skeleton_file_list.rkt CGI script

### DIFF
--- a/src/helpers/skeleton_file_list.rkt
+++ b/src/helpers/skeleton_file_list.rkt
@@ -2,7 +2,7 @@
 #lang racket
 (require net/cgi
          json
-				 file/unzip)
+         file/unzip)
 
 (define skel-file "/u/cs136/public_html/assignment_skeletons/skeletons.json")
 (define skel-template "/u/cs136/public_html/assignment_skeletons/~a-seashell.zip")
@@ -18,11 +18,11 @@
 (define (main)
   (define bindings (get-bindings))
   (define template (extract-binding/single "template" bindings))
-	(define user-list (extract-bindings "user" bindings))
-	(define user (if (empty? user-list) '() (first user-list)))
-	(define wl-list (extract-bindings "whitelist" bindings))
-	(define whitelist (and (not (empty? wl-list)) (string=? (first wl-list) "true")))
-	(define active-skel-template (if whitelist wl-skel-template skel-template))
+  (define user-list (extract-bindings "user" bindings))
+  (define user (if (empty? user-list) '() (first user-list)))
+  (define wl-list (extract-bindings "whitelist" bindings))
+  (define whitelist (and (not (empty? wl-list)) (string=? (first wl-list) "true")))
+  (define active-skel-template (if whitelist wl-skel-template skel-template))
 
   ;; Make sure template shows up in the skeletons file.
   (define wlusers (call-with-input-file wl-u-file read-json))
@@ -31,17 +31,17 @@
   (unless (member template templates)
     (error "Template not present in skeletons file!"))
 
-	(define (is-not-hidden file)
-		(define fname (last (string-split file "/")))
-		(not (char=? #\. (string-ref fname 0))))
+  (define (is-not-hidden file)
+    (define fname (last (string-split file "/")))
+    (not (char=? #\. (string-ref fname 0))))
 
   (write-json 
     `#hash((error . #f)
            (result . ,(filter is-not-hidden
-					 							(map bytes->string/utf-8
-													(zip-directory-entries
-														(read-zip-directory
-															(format active-skel-template template)))))))))
+                         (map bytes->string/utf-8
+                          (zip-directory-entries
+                            (read-zip-directory
+                              (format active-skel-template template)))))))))
 
 ;; Entry point here.
 (printf "Content-Type: text/json\r\n")


### PR DESCRIPTION
This is the updated CGI script which is currently live but was not updated in the repository dating back to last term.

- Changed to work with the new method of storing whitelisted skeletons
- Fixes #600 by not listing hidden files