### PR TITLE
Make ASAN parser detect floating point exception (FPE) error

### DIFF
--- a/src/collects/seashell/backend/asan-error-parse.rkt
+++ b/src/collects/seashell/backend/asan-error-parse.rkt
@@ -284,6 +284,7 @@
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: heap-use-after-free"  "heap-use-after-free")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-use-after-return"  "stack-use-after-return")
         (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: stack-use-after-scope"  "stack-use-after-scope")
+        (match-type #px"^=+\\d+=+ERROR: AddressSanitizer: FPE on unknown address"  "floating-point-exception")
         (match-type #px"^=+\\d+=+ERROR: LeakSanitizer: detected memory leaks" "memory-leak")
         segfault-parser
         memory-leak-parser


### PR DESCRIPTION
Example input program:

```
#include <stdio.h>

int main()
{
  int a = 0;
  scanf("%d\n", &a);
  printf("%d\n", 1/(3-a));
  return 0;
}
```

Example output:

```
Running 'A1/p1':
3
ASAN:DEADLYSIGNAL
Memory error occurred! Type of error: floating-point-exception
current framelist: 0
	frame 0: function main in file test.c at line 7, column 19
Program finished with exit code 1 (An error occurred).
```

Raw asan output (not much useful info to extract):

```
=================================================================
==119751==ERROR: AddressSanitizer: FPE on unknown address 0x00000050d08f (pc 0x00000050d08f bp 0x7fff25c98290 sp 0x7fff25c98280 T0)
    #0 0x50d08e in main /home/yc2lee/.seashell/projects/A1/p1/test.c:10:19
    #1 0x7f2809ba6f44 in __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:287
    #2 0x41a425 in _start (/home/yc2lee/.seashell/runtime-files/test.c-g34-binary+0x41a425)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE /home/yc2lee/.seashell/projects/A1/p1/test.c:10:19 in main
==119751==ABORTING
```
