### PR TITLE
Enrich error messages

### DIFF
--- a/src/frontend/frontend/errors.js
+++ b/src/frontend/frontend/errors.js
@@ -20,8 +20,8 @@
 
 angular.module('frontend-app')
   // Error service.
-  .service('error-service', ['$rootScope', '$timeout', '$sce',
-    function ($rootScope, $timeout, $sce) {
+  .service('error-service', ['$rootScope', '$timeout', 
+    function ($rootScope, $timeout) {
       
     var self = this;
 
@@ -31,11 +31,6 @@ angular.module('frontend-app')
 
     // how many entries to keep in self.logs
     var logSize = 200;
-
-    // bug report email format
-    self.reportTo = "seashell@cs.uwaterloo.ca";
-    self.reportSubject = "seashell@cs.uwaterloo.ca";
-    self.reportBody = "Tell us what you were doing when this error showed up. \n[paste the log here]";
 
     // override console.log so that it also logs to self.logs
     logConsoleFn("log");
@@ -98,7 +93,14 @@ angular.module('frontend-app')
             } catch (e) {
                 return JSON.stringify(e);
             }
-        }).join("\n");
+        }).join(" ");
     }
+
+    // bug report email format
+    self.reportTo = "seashell@cs.uwaterloo.ca";
+    self.reportSubject = "Seashell issue report";
+    self.reportBody = function() {
+        return encodeURIComponent("[Tell us what you were doing when this error showed up.]\n\n" + self.dumpLogs());
+    };
 
 }]);

--- a/src/frontend/frontend/errors.js
+++ b/src/frontend/frontend/errors.js
@@ -29,6 +29,9 @@ angular.module('frontend-app')
     self.errors = [];
     self.logs = [];
 
+    // how many entries to keep in self.logs
+    var logSize = 200;
+
     // bug report email format
     self.reportTo = "seashell@cs.uwaterloo.ca";
     self.reportSubject = "seashell@cs.uwaterloo.ca";
@@ -79,13 +82,16 @@ angular.module('frontend-app')
         window.console[fn] = function() {
             defaultFn.apply(window.console, arguments);
             self.logs.push({type: fn, text: prettyLogMsg.apply(this, arguments)});
+            if (self.logs.length > logSize) {
+                self.logs.shift();
+            }
         };
     }
 
     // format a console.log message to human readable string
     // eg. prettyLogMsg(object1, object2, object3, ...);
     function prettyLogMsg() {
-        return Array.from(arguments).map(function(arg) {
+        return Array.prototype.slice.call(arguments).map(function(arg) {
             try {
                 // in case the object is recursive
                 return JSON.stringify(arg);

--- a/src/frontend/frontend/errors.js
+++ b/src/frontend/frontend/errors.js
@@ -98,7 +98,7 @@ angular.module('frontend-app')
 
     // bug report email format
     self.reportTo = "seashell@cs.uwaterloo.ca";
-    self.reportSubject = "Seashell issue report";
+    self.reportSubject = encodeURIComponent("Seashell issue report");
     self.reportBody = function() {
         return encodeURIComponent("[Tell us what you were doing when this error showed up.]\n\n" + self.dumpLogs());
     };

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -35,6 +35,7 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'ngCo
         self.offline_mode = false;
         self.has_offline_changes = false;
         self.errors = errors;
+        $scope.navigator = navigator;
         var cookie = $cookies.getObject(SEASHELL_CREDS_COOKIE);
         if(cookie) {
           self.host = cookie.host;
@@ -50,8 +51,8 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'ngCo
             controller: ['$scope', 'ConfirmationMessageModal', '$window',
               '$cookies',
               function ($scope, confirm, $window, $cookies) {
-                $scope.login = function () {
-                  self.login();
+                $scope.login = function (reset) {
+                  self.login(reset);
                   $scope.$dismiss();
                 };
                 $scope.archive = function() {
@@ -121,8 +122,8 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'ngCo
           ws.connect();
         };
         // Open login dialog window after disconnection
-        self.login = function() {
-          new LoginModal().then(function() {
+        self.login = function(reset) {
+          new LoginModal(reset).then(function() {
           });
         };
 

--- a/src/frontend/frontend/includes/body.html
+++ b/src/frontend/frontend/includes/body.html
@@ -34,9 +34,9 @@
   <alert ng-repeat="error in frontend.errors.errors" ng-cloak
     type="danger" close="frontend.errors.suppress($index)" role="alert">
     <p><b>An error has occurred: </b>{{error.shorthand}}
-    <span ng-show="error.type == 'marmoset'">Make sure you can still access Marmoset's web interface, and try again in a few minutes.</span>
-    <span ng-show="error.type == 'webserver'">Make sure you can access other websites located on the student.cs.uwaterloo.ca subdomain and try again in a few minutes.</span>
-    <span ng-show="error.type == 'seashell' || ! error.type">Try refreshing the page or <a href="" ng-click="frontend.login(true)">resetting Seashell</a>. If the error persists, please email <a href="" ng-click="frontend.errors.dumpLogsNewWindow()">this log</a> to <a href='mailto:{{frontend.errors.reportTo}}?subject={{frontend.errors.reportSubject}}&body={{frontend.errors.reportBody}}'>{{frontend.errors.reportTo}}</a> and tell us what you are doing.</span>
+    <span ng-if="error.type == 'marmoset'">Make sure you can still access Marmoset's web interface, and try again in a few minutes.</span>
+    <span ng-if="error.type == 'webserver'">Make sure you can access other websites located on the student.cs.uwaterloo.ca subdomain and try again in a few minutes.</span>
+    <span ng-if="error.type == 'seashell' || ! error.type">Try refreshing the page or <a href="" ng-click="frontend.login(true)">resetting Seashell</a>. If the error persists, please email <a href="" ng-click="frontend.errors.dumpLogsNewWindow()">this log</a> to <a href='mailto:{{frontend.errors.reportTo}}?subject={{frontend.errors.reportSubject}}&body={{frontend.errors.reportBody()}}'>{{frontend.errors.reportTo}}</a> and tell us what you are doing.</span>
     </p>
     <pre ng-cloak>
     error:       {{error.error}}

--- a/src/frontend/frontend/includes/body.html
+++ b/src/frontend/frontend/includes/body.html
@@ -33,12 +33,17 @@
   
   <alert ng-repeat="error in frontend.errors.errors" ng-cloak
     type="danger" close="frontend.errors.suppress($index)" role="alert">
-    <b>An error has occurred: </b>{{error.shorthand}} <span ng-bind-html="frontend.errors.getMessage(error.type)"></span>
+    <p><b>An error has occurred: </b>{{error.shorthand}}
+    <span ng-show="error.type == 'marmoset'">Make sure you can still access Marmoset's web interface, and try again in a few minutes.</span>
+    <span ng-show="error.type == 'webserver'">Make sure you can access other websites located on the student.cs.uwaterloo.ca subdomain and try again in a few minutes.</span>
+    <span ng-show="error.type == 'seashell' || ! error.type">Try refreshing the page or <a href="" ng-click="frontend.login(true)">resetting Seashell</a>. If the error persists, please email <a href="" ng-click="frontend.errors.dumpLogsNewWindow()">this log</a> to <a href='mailto:{{frontend.errors.reportTo}}?subject={{frontend.errors.reportSubject}}&body={{frontend.errors.reportBody}}'>{{frontend.errors.reportTo}}</a> and tell us what you are doing.</span>
+    </p>
     <pre ng-cloak>
-version:     @(values SEASHELL_VERSION) (@(values SEASHELL_BRANCH) at @(values SEASHELL_COMMIT))
-api_version: @(values SEASHELL_API_VERSION)
-host:        {{frontend.host}}
-error:       {{error.error}}</pre>
+    error:       {{error.error}}
+    version:     @(values SEASHELL_VERSION) (@(values SEASHELL_BRANCH) at @(values SEASHELL_COMMIT))
+    browser:     {{navigator.appVersion}}
+    api_version: @(values SEASHELL_API_VERSION)
+    host:        {{frontend.host}}</pre>
   </alert>
 
   <div ui-view></div>

--- a/src/frontend/frontend/modals.js
+++ b/src/frontend/frontend/modals.js
@@ -33,13 +33,13 @@ angular.module('frontend-app')
       }])
   .factory('LoginModal', ['$modal',
       function($modal) {
-        return function() { return $modal.open({
+        return function(reset) { return $modal.open({
           templateUrl: "frontend/templates/login-template.html",
           controller: ['$scope', '$window', '$cookies', 'socket',
             function($scope, $window, $cookies, ws) {
               $scope.username = "";
               $scope.password = "";
-              $scope.reset = false;
+              $scope.reset = reset || false;
               $scope.busy = false;
               $scope.error = false;
 

--- a/src/frontend/frontend/templates/help-template.html
+++ b/src/frontend/frontend/templates/help-template.html
@@ -10,7 +10,7 @@
         <br /><br />
         <h4>Reset Seashell</h4>
         It often helps to reset your Seashell instance if it gets locked
-        up in some way. To do this, <a href="" ng-click="login()">log in again</a>,
+        up in some way. To do this, <a href="" ng-click="login(true)">log in again</a>,
         and check the box labeled "Check to reset your Seashell instance."
         <br /><br />
         <h4>Cluttered old projects?</h4>

--- a/src/frontend/js/socket/websocket_client.js
+++ b/src/frontend/js/socket/websocket_client.js
@@ -100,7 +100,7 @@ function SeashellWebsocket(uri, key, failure, closes) {
           var time = new Date();
           var diff = request.time ? time - request.time : 'NA';
 
-          console.log("Received response to message with id %d after %d ms.", response.id, diff);
+          console.log("Received response to message with id "+response.id+" after "+diff+" ms.");
 
           var displayRequest = Object.assign({}, request);
           delete displayRequest.time; // hide from console
@@ -184,13 +184,23 @@ SeashellWebsocket.prototype._sendMessage = function(message, deferred) {
   var request_id = self.lastRequest++;
 
   message.time = new Date();
-  
+
   self.requests[request_id] = message;
   message.id = request_id;
   // Stringify, write out as Array of bytes.
   var blob = new Blob([JSON.stringify(message)]);
   // Grab a deferred for the message:
   self.requests[request_id].deferred = deferred || $.Deferred();
+
+  // log to console
+  if (message.type != 'ping') {
+    var displayMsg = Object.assign({}, message);
+    delete displayMsg.deferred; // hide defer field
+    delete displayMsg.time;  // hide time field
+    console.log("Sent request with id "+request_id+".");
+    console.log(displayMsg);
+  }
+  
   try {
     // Send the message:
     self.websocket.send(blob);

--- a/src/frontend/js/socket/websocket_client.js
+++ b/src/frontend/js/socket/websocket_client.js
@@ -96,8 +96,17 @@ function SeashellWebsocket(uri, key, failure, closes) {
         var request = self.requests[response.id];
 
         if (request.type != 'ping') {
-          console.log("Received response to message with id: "+response.id+".");
-          console.log(request);
+
+          var time = new Date();
+          var diff = request.time ? time - request.time : 'NA';
+
+          console.log("Received response to message with id %d after %d ms.", response.id, diff);
+
+          var displayRequest = Object.assign({}, request);
+          delete displayRequest.time; // hide from console
+          delete displayRequest.deferred; // hide from console
+          console.log(displayRequest);
+
           if (! response.success) {
             console.error(response);
           } else {
@@ -173,6 +182,9 @@ SeashellWebsocket.prototype._sendMessage = function(message, deferred) {
   var self = this;
   // Reserve a slot for the message.
   var request_id = self.lastRequest++;
+
+  message.time = new Date();
+  
   self.requests[request_id] = message;
   message.id = request_id;
   // Stringify, write out as Array of bytes.

--- a/src/frontend/js/socket/websocket_client.js
+++ b/src/frontend/js/socket/websocket_client.js
@@ -98,7 +98,11 @@ function SeashellWebsocket(uri, key, failure, closes) {
         if (request.type != 'ping') {
           console.log("Received response to message with id: "+response.id+".");
           console.log(request);
-          console.log(response);
+          if (! response.success) {
+            console.error(response);
+          } else {
+            console.log(response);
+          }
         }
 
         if (response.success) {


### PR DESCRIPTION
1. display browser info in the error message (browsers tend to lie in userAgent but I couldn't find a better way. at least userAgent gives us a string we can then google for)
2. show a link that has log trace in the error message, recommend user to report the log trace
3. put a reset seashell button in the error message
4. websocket success:false responses are reported with console.error instead of console.log
5. also cleaned up some ugly code. this probably solves the problem where people are getting empty {} error messages.
6. reset seashell? check box is auto selected when appropriate'
7. Add response time to websocket console.log
8. Remove .defer field from websocket console.log
9. websocket request are logged at the time they are sent