### PR TITLE
"Offline-first" saving

### DIFF
--- a/src/frontend/js/storage-service.js
+++ b/src/frontend/js/storage-service.js
@@ -31,8 +31,30 @@
           projects: 'name',
           settings: 'name'
         });
+        self.database.version(2).stores({
+          changelog: '++id',
+          files: '[project+file], project',
+          projects: 'name',
+          settings: 'name',
+          meta: 'key'
+        }).upgrade(function(ts) {
+          ts.meta.add({key:"init"});
+        });
 
         self.has_offline_changes = false;
+
+        self.isInitialized = function() {
+          return self.database.meta.get("init").then(function(init) {
+            return init !== undefined;
+          }).catch(function(err) {
+            console.log(err);
+            return false;
+          });
+        };
+
+        self.setInitialized = function() {
+          return self.database.meta.put({key:"init"});
+        };
 
         /*
          * Save a file to local storage.
@@ -295,7 +317,7 @@
       };
 
       self.applyChanges = function (changes, newProjects, deletedProjects, updatedProjects, settings) {
-        return self.database.transaction('rw', self.database.files, self.database.changelog, self.database.projects, self.database.settings, function () {
+        return self.database.transaction('rw', self.database.files, self.database.changelog, self.database.projects, self.database.settings, self.database.meta, function () {
           Dexie.currentTransaction.on('abort', function(ev) {
             console.log("applyChanges transaction aborted", ev);
             throw ev.target.error;
@@ -324,6 +346,7 @@
             self.saveSettings(JSON.parse(settings));
           }
           self.database.changelog.clear();
+          self.setInitialized();
         });
       };
 

--- a/src/frontend/js/storage-service.js
+++ b/src/frontend/js/storage-service.js
@@ -37,8 +37,6 @@
           projects: 'name',
           settings: 'name',
           meta: 'key'
-        }).upgrade(function(ts) {
-          ts.meta.add({key:"init"});
         });
 
         self.has_offline_changes = false;

--- a/src/frontend/js/websocket-service.js
+++ b/src/frontend/js/websocket-service.js
@@ -296,39 +296,8 @@ angular.module('seashell-websocket', ['ngCookies', 'seashell-local-files', 'seas
               });
             }
             else {
-              if(self.isOffline())
-                return localfiles[name].apply(localfiles, args);
-              else
-                return $q.when(self._socket[name].apply(self._socket, args));
-            }
-            /*if (self.isOffline()) {
-              console.log(sprintf("Invoking %s in offline mode.", name));
               return localfiles[name].apply(localfiles, args);
-            } else {
-              return $q.when(self._socket[name].apply(self._socket, args))
-                .then(function (result) {
-                  if (offlineWriteThrough) {
-                    console.log(sprintf("Invoking %s in write-through mode.", name));
-                    var write_through_args = args
-                      .concat(new Array(online_arity - args.length))
-                      .concat([result]);
-                    return localfiles[name].apply(localfiles, write_through_args)
-                      .then(function() {
-                        return result;
-                      });
-                  } else {
-                    return result;
-                  }
-                })
-                .catch(function (error) {
-                  if (self.isOffline()) {
-                    console.log(sprintf("Invoking %s in offline mode.", name));
-                    return localfiles[name].apply(localfiles, args);
-                  } else {
-                    return $q.reject(error);
-                  }
-                });
-            }*/
+            }
           } else {
             return $q.when(self._socket[name].apply(self._socket, args));
           }
@@ -482,9 +451,6 @@ angular.module('seashell-websocket', ['ngCookies', 'seashell-local-files', 'seas
               });
           })
           .then(function (changes) {
-            /*if(self.connected) {
-              self.invoke_cb('connected', self.isOffline() ? self.offline_mode : false);
-            }*/
             self.isSyncing = false;
             // send the changes back in case we need to act on the files that have
             //  changed within the open project


### PR DESCRIPTION
- When offline mode is enabled, all writes will save to local storage first then try to sync.
- Reads will also by default read from the local storage.
- Remove separate "connected" and "syncing" events which are not necessary with this change
- The local storage is aware of whether or not it has had an initial sync, and if it has not then it will reject requests until it is synced.