### PR TITLE
change editor over to monaco, hook settings up to editor, basic file …

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -22,6 +22,7 @@
     "react-addons-css-transition-group": "^15.4.2",
     "react-codemirror": "^0.3.0",
     "react-dom": "^15.3.2",
+    "react-monaco-editor": "^0.7.3",
     "react-redux": "^4.4.6",
     "react-router": "^2.8.1",
     "redux": "^3.6.0",

--- a/src/frontend/src/actions/index.ts
+++ b/src/frontend/src/actions/index.ts
@@ -4,6 +4,7 @@ import { globalState } from '../reducers/';
 import {projectRef, fileRef} from '../types';
 import {appStateActions} from '../reducers/appStateReducer';
 import {settingsActions, settingsReducerState} from '../reducers/settingsReducer';
+import {fileActions, fileReducerState} from '../reducers/fileReducer';
 
 interface Func<T> {
     ([...args]: any): T;
@@ -20,6 +21,9 @@ const mapDispatchToProps = (dispatch:Function) => {
         dispatch: {
           settings: {
              updateSettings:(newSettings: settingsReducerState)=>dispatch({type: settingsActions.updateSettings, payload: newSettings})
+          },
+          file: {
+              updateFile:(newFileContent: fileReducerState)=>dispatch({type: fileActions.changeContent, payload: newFileContent})
           }
         }
     }

--- a/src/frontend/src/partials/Navigation/Dialogs.tsx
+++ b/src/frontend/src/partials/Navigation/Dialogs.tsx
@@ -105,8 +105,8 @@ class SettingsDialog extends React.Component<DialogProps&actionsInterface&Settin
                 <div className="pt-control-group">
                 <div className="pt-select" >
                 <select id="theme_style" value={String(this.state.theme)} onChange={(e)=>this.setState(merge(this.state, {theme: Number(e.target.value),}))}>
-                  <option value="0">light</option>
-                  <option value="1">dark</option>
+                  <option value="0">dark</option>
+                  <option value="1">light</option>
                 </select>
                 </div>
               </div>

--- a/src/frontend/src/reducers/fileReducer.ts
+++ b/src/frontend/src/reducers/fileReducer.ts
@@ -5,13 +5,16 @@ export interface fileReducerState {[key: string]: any;
     content?: string;
 };
 export interface fileReducerAction {type: string, payload: fileReducerState}
-export const appStateActions = {
+export const fileActions = {
   changeName: 'file_change_name',
+  changeContent: 'file_change_content'
 };
 export default function fileReducer(state:fileReducerState = {name: "default.c"}, action:fileReducerAction={type:null, payload:{}}) {
   switch (action.type) {
-    case appStateActions.changeName:
-      return evolve(state, {name: action.payload.name});
+    case fileActions.changeContent:
+      return evolve(state, {name: state.name, content: action.payload.content});
+    case fileActions.changeName:
+      return evolve(state, {name: action.payload.name, content: state.content});
     default:
       return state;
   }

--- a/src/frontend/typings/index.d.ts
+++ b/src/frontend/typings/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'offline-plugin/runtime';
 declare module 'react-codemirror';
+declare module 'react-monaco-editor';
 
 declare var require: {
    <T>(path: string): T;

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = {
   entry: [
     './src/index.tsx'
@@ -15,6 +16,12 @@ module.exports = {
       template: './src/index.html',
       filename: '../index.html',
     }),
+      new CopyWebpackPlugin([
+      {
+        from: './node_modules/monaco-editor/min/vs',
+        to: 'vs',
+      }
+    ])
   ],
   devtool: "source-map",
   resolve: {


### PR DESCRIPTION
…reducer and action added

*note: the editor loads once and does not seem to re-render every time the settings state is updated, like it should, so if you change the settings, you will have to navigate away and go back to see them made. The file reducers and actions have been implemented, but in order to see the changes to files made, this new file state seems to need to be put into the bigger projectlist hierarchy. This has not been done yet.