### PR TITLE
Add extra space before default comment text

### DIFF
--- a/src/frontend/frontend/modals.js
+++ b/src/frontend/frontend/modals.js
@@ -273,10 +273,10 @@ angular.module('frontend-app')
                   // Write default contents.
                   if (extension === 'c' || extension === 'h') {
                       result = project.createFile($scope.new_file_folder, question, filename,
-                                        sprintf("/**\n File: %s\nEnter a description for this file.\n*/\n", filename));
+                                        sprintf("/**\n File: %s\n Enter a description for this file.\n*/\n", filename));
                   } else if (extension === 'rkt') {
                       result = project.createFile($scope.new_file_folder, question, filename,
-                                        sprintf("#lang racket\n;; File %s\n;;Enter a description for this file.\n", filename));
+                                        sprintf("#lang racket\n;; File %s\n;; Enter a description for this file.\n", filename));
                   } else {
                       result = project.createFile($scope.new_file_folder, question, filename);
                   }


### PR DESCRIPTION
Adjust spacing for default comments for .c, .h, .rkt files created in Seashell.

Before (Racket):
`;;Enter a description for this file.`
After (Racket):
`;; Enter a description for this file.`

Before (C):
```
/**
 File: a.c
Enter a description for this file.
*/
```
After (C):
```
/**
 File: a.c
 Enter a description for this file.
*/
```