### PR TITLE
Compiler skeleton code and moving connect() code into SeashellWebsocket class

### DIFF
--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -2,6 +2,7 @@ import {ProjectID, FileID, File} from "../Storage/Interface";
 
 export {AbstractCompiler,
         CompilerResult,
+        CompilerMessage,
         Test,
         PID};
 

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -7,7 +7,7 @@ export {AbstractCompiler,
         PID};
 
 abstract class AbstractCompiler {
-  public abstract async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult>;
+  public abstract async compileAndRunProject(proj: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult>;
   public async programKill(pid: PID): Promise<void> {
     return pid.kill();
   }

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -1,0 +1,44 @@
+import {ProjectID, FileID, File} from "../Storage/Interface";
+
+export {AbstractCompiler,
+        CompilerResult,
+        Test,
+        PID};
+
+abstract class AbstractCompiler {
+  public abstract async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult>;
+  public async programKill(pid: PID): Promise<void> {
+    return pid.kill();
+  }
+  public async sendEOF(pid: PID): Promise<void> {
+    return pid.sendEOF();
+  }
+  public abstract async programInput(pid: PID, contents: string): Promise<void>;
+  public abstract async startIO(project: ProjectID, pid: PID): Promise<void>;
+}
+
+interface Test {
+  in: File;
+  expect: File;
+}
+
+interface PID {
+  source: AbstractCompiler;
+  kill(): Promise<void>;
+  sendEOF(): Promise<void>;
+  startIO(): Promise<void>;
+}
+
+interface CompilerResult {
+  messages: CompilerMessage[];
+  pid: PID;
+  status: string;
+}
+
+interface CompilerMessage {
+  error: boolean;
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+}

--- a/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
@@ -1,11 +1,23 @@
-import {AbstractCompiler, PID, Test, CompilerResult} from "./Interface";
-import {ProjectID, FileID} from "../Storage/Interface";
+import {AbstractCompiler,
+        PID,
+        Test,
+        CompilerResult} from "./Interface";
+import {AbstractStorage,
+        ProjectID,
+        FileID} from "../Storage/Interface";
 
 export {OfflineCompiler};
 
 class OfflineCompiler extends AbstractCompiler {
 
-  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult> {
+  private storage: AbstractStorage;
+
+  constructor(storage: AbstractStorage) {
+    super();
+    this.storage = storage;
+  }
+
+  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult> {
     return {
       messages: [],
       pid: null,

--- a/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
@@ -1,0 +1,23 @@
+import {AbstractCompiler, PID, Test, CompilerResult} from "./Interface";
+import {ProjectID, FileID} from "../Storage/Interface";
+
+export {OfflineCompiler};
+
+class OfflineCompiler extends AbstractCompiler {
+
+  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult> {
+    return {
+      messages: [],
+      pid: null,
+      status: "failed"
+    };
+  }
+
+  public async programInput(pid: PID, contents: string): Promise<void> {
+
+  }
+
+  public async startIO(project: ProjectID, pid: PID): Promise<void> {
+
+  }
+}

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -19,7 +19,10 @@ class OnlineCompiler extends AbstractCompiler {
     this.offlineCompiler = offComp;
   }
   
-  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult> {
+  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult> {
+    if(!this.socket.isConnected()) {
+      return this.offlineCompiler.compileAndRunProject(proj, question, file, runTests);
+    }
     return {
       messages: [],
       pid: null,

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -1,0 +1,35 @@
+import {SeashellWebsocket, WebsocketResult} from "../Websocket/WebsocketClient";
+import {Connection} from "../Services";
+import {AbstractCompiler, Test, PID, CompilerResult} from "./Interface";
+import {OfflineCompiler} from "./OfflineCompiler";
+import {AbstractStorage, ProjectID, FileID} from "../Storage/Interface";
+
+export {OnlineCompiler};
+
+class OnlineCompiler extends AbstractCompiler {
+
+  private socket: SeashellWebsocket;
+  private storage: AbstractStorage;
+  private offlineCompiler: OfflineCompiler;
+
+  constructor(socket: SeashellWebsocket, storage: AbstractStorage, offComp: OfflineCompiler) {
+    super();
+    this.socket = socket;
+    this.storage = storage;
+    this.offlineCompiler = offComp;
+  }
+  
+  public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, tests: Test[]): Promise<CompilerResult> {
+    return {
+      messages: [],
+      pid: null,
+      status: "failed"
+    };
+  }
+
+  public async programInput(pid: PID, contents: string): Promise<void> {
+  }
+
+  public async startIO(project: ProjectID, pid: PID): Promise<void> {
+  }
+}

--- a/src/frontend/src/helpers/Services.ts
+++ b/src/frontend/src/helpers/Services.ts
@@ -1,5 +1,5 @@
 import * as $ from "jquery";
-import {SeashellWebsocket} from "./Websocket/WebSocketClient";
+import {SeashellWebsocket} from "./Websocket/WebsocketClient";
 import {WebStorage} from "./Storage/WebStorage";
 import {LocalStorage} from "./Storage/LocalStorage";
 import {AbstractStorage,

--- a/src/frontend/src/helpers/Services.ts
+++ b/src/frontend/src/helpers/Services.ts
@@ -6,7 +6,15 @@ import {AbstractStorage,
         File, FileID, FileBrief,
         Project, ProjectID, ProjectBrief,
         Settings, defaultSettings} from "./Storage/Interface";
+import {OnlineCompiler} from "./Compiler/OnlineCompiler";
+import {OfflineCompiler} from "./Compiler/OfflineCompiler";
+import {AbstractCompiler,
+        Test,
+        CompilerResult,
+        CompilerMessage} from "./Compiler/Interface";
+
 export * from "./Storage/Interface";
+export * from "./Compiler/Interface";
 export {Services, LoginError, Connection};
 
 class LoginError extends Error {
@@ -35,11 +43,15 @@ namespace Services {
   const socketClient: SeashellWebsocket = new SeashellWebsocket();
   const localStorage: LocalStorage = new LocalStorage();
   const webStorage: WebStorage = new WebStorage(socketClient, localStorage);
-  // private static compile: Compiler;
-
+  const offlineCompiler: OfflineCompiler = new OfflineCompiler();
+  const onlineCompiler: OnlineCompiler = new OnlineCompiler(socketClient, webStorage, offlineCompiler);
 
   export function storage(): WebStorage {
     return webStorage;
+  }
+
+  export function compiler(): AbstractCompiler {
+    return onlineCompiler;
   }
 
   export async function login(user: string,

--- a/src/frontend/src/helpers/Services.ts
+++ b/src/frontend/src/helpers/Services.ts
@@ -85,8 +85,7 @@ namespace Services {
 
     // login successful
     await localStorage.connect(`seashell-${connection.username}`);
-    await socketClient.authenticate(connection);
-    await socketClient.connect();
+    await socketClient.connect(connection);
   }
 
   export async function logout() {

--- a/src/frontend/src/helpers/Services.ts
+++ b/src/frontend/src/helpers/Services.ts
@@ -43,7 +43,7 @@ namespace Services {
   const socketClient: SeashellWebsocket = new SeashellWebsocket();
   const localStorage: LocalStorage = new LocalStorage();
   const webStorage: WebStorage = new WebStorage(socketClient, localStorage);
-  const offlineCompiler: OfflineCompiler = new OfflineCompiler();
+  const offlineCompiler: OfflineCompiler = new OfflineCompiler(localStorage);
   const onlineCompiler: OnlineCompiler = new OnlineCompiler(socketClient, webStorage, offlineCompiler);
 
   export function storage(): WebStorage {
@@ -86,10 +86,10 @@ namespace Services {
     // login successful
     await localStorage.connect(`seashell-${connection.username}`);
     await socketClient.authenticate(connection);
-    await webStorage.connect();
+    await socketClient.connect();
   }
 
   export async function logout() {
-    await socketClient.close();
+    await socketClient.disconnect();
   }
 }

--- a/src/frontend/src/helpers/Storage/WebStorage.ts
+++ b/src/frontend/src/helpers/Storage/WebStorage.ts
@@ -16,23 +16,12 @@ class Callback {
 
 class WebStorage extends AbstractStorage {
   // private synced: boolean;
-  private connected: boolean;
-  private failed: boolean;
   // private isSyncing: boolean;
   private offlineMode: number;
-  private timeoutCount: number;
-  private timeoutInterval: any;
-  private key: number;
 
-  private callbacks: Callback[];
   private socket: SeashellWebsocket;
   private storage: LocalStorage;
 
-  private compiler: SeashellCompiler;
-  private runner: SeashellRunner;
-  private tester: SeashellTester;
-
-  public ping: () => Promise<WebsocketResult>;
   public newProjectFrom: (name: string, src_url: string) => Promise<WebsocketResult>;
   // public deleteProject: (name: string) => Promise<WebsocketResult>;
   public restoreFileFrom: (name: string, file: string, contents: string, history: History) => Promise<WebsocketResult>;
@@ -59,16 +48,10 @@ class WebStorage extends AbstractStorage {
   constructor(wbclient: SeashellWebsocket, store: LocalStorage, debug?: boolean) {
     super();
     // this.synced = false;
-    this.connected = false;
-    this.failed = false;
     // this.isSyncing = false;
     this.offlineMode = 0; // TODO change this to look up the cookie
-    this.timeoutCount = 0;
-    this.timeoutInterval = null;
-    this.key = 0;
     this.storage = store;
     this.socket = wbclient;
-    this.callbacks = [];
     this.debug = debug;
     this.socket.debug = debug;
 

--- a/src/frontend/src/helpers/Storage/WebStorage.ts
+++ b/src/frontend/src/helpers/Storage/WebStorage.ts
@@ -289,7 +289,7 @@ class WebStorage extends AbstractStorage {
     }
     if (old === 2 && this.offlineMode !== old) {
       // trigger reconnect and sync
-      if (!this.socket.isConnected())
+      if(!this.socket.isConnected())
         this.socket.connect();
       else {
         this.syncAll();

--- a/src/frontend/src/helpers/Websocket/WebsocketClient.ts
+++ b/src/frontend/src/helpers/Websocket/WebsocketClient.ts
@@ -74,32 +74,39 @@ class Response {
   result: WebsocketResult;
 }
 
+class Callback {
+  constructor(public type: string, public cb: (message?: any) => any, public now: boolean) { }
+}
 
 class SeashellWebsocket {
-  private static cnn: Connection;
-  private static coder: ShittyCoder;
-  private static websocket: WebSocket;
-  private lastRequest: number;
+  private cnn: Connection;
+  private coder: ShittyCoder;
+  private websocket: WebSocket;
+  private lastMsgID: number;
   public requests: {[index:number]: Request<any>};
-  // public ready: Promise<boolean>;
-  public authenticated: boolean;
+  private authenticated: boolean;
   private failed: boolean;
   private closed: boolean;
   private started: boolean;
   private closes: () => void;
-  private falures: () => void;
+  private failures: () => void;
   public debug: boolean; // toggle console.log for tests
 
-  // this allows WebsocketService to access member functions by string key
-  [key: string]: any;
+  private timeoutCount: number;
+  private timeoutInterval: any;
+  private key: number;
+  private callbacks: Callback[];
 
-  constructor() {
+  // this allows WebsocketService to access member functions by string key
+  //[key: string]: any;
+
+  constructor(debug?: boolean) {
     this.lastMsgID = 0;
     this.authenticated = false;
     this.failed = false;
     this.closed = false;
     this.started = false;
-    this.debug = true;
+    this.debug = !!debug;
     this.requests = {};
     this.requests[-1] = new Request({id: -1}); // server challenge
     this.requests[-2] = new Request({id: -2}); // reply challenge
@@ -107,6 +114,9 @@ class SeashellWebsocket {
     this.requests[-4] = new Request({id: -4});
     // this.ready = new Promise((resolve, reject)=>{
     this.started = true;
+    this.timeoutCount = 0;
+    this.timeoutInterval = null;
+    this.callbacks = [];
   }
 
   public onFailure(callbacks: () => void) {
@@ -115,10 +125,6 @@ class SeashellWebsocket {
 
   public onClose(callbacks: () => void) {
     this.closes = callbacks;
-  }
-
-  public close(): void {
-    this.websocket.close();
   }
 
   // public async answerChallenge(serverChallenge: Uint8Array): Promise<{}>
@@ -205,6 +211,92 @@ class SeashellWebsocket {
     }
   }
 
+  // Connects the socket, sets up the disconnection monitor
+  public async connect(): Promise<void> {
+    // Failure - probably want to prompt the user to attempt to reconnect or
+    //  log in again
+    this.onFailure(async () => {
+      clearInterval(this.timeoutInterval);
+      try {
+        await this.invoke_cb('failed');
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+    // Socket closed - probably want to prompt the user to reconnect
+    this.onClose(async () => {
+      clearInterval(this.timeoutInterval);
+      try {
+        await this.invoke_cb('disconnected');
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+    if(!this.authenticated) {
+      await this.invoke_cb('failed');
+      throw new WebsocketError("socket is not authenticated");
+    }
+
+    this.debug && console.log("Seashell socket set up properly");
+    this.timeoutInterval = setInterval(async () => {
+      try {
+        if (this.timeoutCount++ === 3) {
+          this.invoke_cb('timeout');
+        }
+        await this.ping();
+        if (this.timeoutCount >= 3) {
+          this.invoke_cb('timein');
+        }
+        this.timeoutCount = 0;
+      } catch (err) {
+        console.error(err);
+      }
+    }, 4000);
+    this.requests[-3].callback = this.io_cb;
+    this.requests[-4].callback = this.test_cb;
+    this.debug && console.log("Websocket disconnection monitor set up properly.");
+    // Run the callbacks.
+    await this.invoke_cb('connected');
+  }
+
+  public disconnect(): void {
+    this.websocket.close();
+  }
+
+   public register_callback(type: string, cb: (message?: any) => any, now?: boolean) : number {
+    this.callbacks[this.key] = new Callback(type, cb, now);
+
+    if(type === 'disconnected' && !this.isConnected() && now) {
+      cb();
+    } else if(type === 'connected' && this.isConnected() && now) {
+      cb();
+    } else if(type === 'failed' && this.failed && now) {
+      cb();
+    }
+    return this.key++;
+  }
+
+  public unregister_callback(key: number) : void {
+    delete this.callbacks[key];
+  }
+
+  public async invoke_cb(type: string, message?: any): Promise<Array<any>> {
+    return this.callbacks.filter(
+      (x: Callback) => { return x && x.type === type; }).map(
+        async (x: Callback) => { return x.cb(message); });
+  }
+
+  // Helper function to invoke the I/O callback.
+  public io_cb(ignored: any, message: any) {
+    return this.invoke_cb('io', message);
+  }
+
+  public test_cb(ignored: any, message: any) {
+    return this.invoke_cb('test', message);
+  } 
+
   /** Sends a message along the connection. Internal use only.
    *
    * @param {Object} message - JSON message to send (as JavaScript object).
@@ -234,12 +326,16 @@ class SeashellWebsocket {
    *  sends the message after the socket has been properly
    *  authenticated/set up. */
   public sendMessage(message: Message): Promise<any> {
-    if (this.failed || this.closed || ! this.started) {
+    if(!this.isConnected()) {
       throw new WebsocketError("Socket closed or failed");
     }
     var msgID = this.lastMsgID++;
     message.id = msgID;
     return this.sendRequest(new Request(message));
+  }
+
+  public isConnected() {
+    return !(this.failed || this.closed || !this.started);
   }
 
   /** The following functions are wrappers around sendMessage.
@@ -253,7 +349,7 @@ class SeashellWebsocket {
     });
   }
 
-  public async compileAndRunProject(project: string, question: string, test: Array<string>): Promise<WebsocketResult> {
+  /*public async compileAndRunProject(project: string, question: string, test: Array<string>): Promise<WebsocketResult> {
     return await this.sendMessage({
       type: 'compileAndRunProject',
       project: project,
@@ -366,5 +462,5 @@ class SeashellWebsocket {
   public async sync(message: Message) {
     message.type = 'sync';
     return await this.sendMessage(message);
-  }
+  }*/
 }


### PR DESCRIPTION
Moving the connect() code and the callback-related stuff into SeashellWebsocket allows the Compiler and Storage to easily tell when the websocket is connected. Also allows some simplification of the code.

This is (hopefully) close to the final version of the interface the React code will see.