### PR TITLE
Display student's program output if timeout or killed. Show reminders…

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -196,6 +196,10 @@
       (cons 'header-search-depth           5)
       ;; Number of seconds a program can run without I/O before timing out
       (cons 'program-run-timeout           30)
+      ;; Maximum number of bytes of output (stdout and stderr each) that the backend will send to the
+      ;; frontend when a test times out or is killed. This is to prevent a massive amount of data from
+      ;; being sent to the frontend when students do infinite loops.
+      (cons 'max-output-bytes-to-keep      10000)
       ;; Optional login tracking helper.  (Runs whenever a user logs in.)
       (cons 'login-tracking-helper         #f)
       ;; Enable debug mode execution (corresponds to seashell-numeric-debug value by default)
@@ -234,6 +238,12 @@
       ;; Memory Limits
       (cons 'server-memory-limit 1024) ;; 1G
       (cons 'request-memory-limit 128) ;; 128M
+      ;; This is the buffer size for output from the student's program. It should be less
+      ;; than request-memory-limit above. If the student's program writes more than this amount
+      ;; of output, the excess is thrown away. This limit is needed because if students write a
+      ;; lot of output, it consumes a lot of memory and the request-memory-limit limit above
+      ;; doesn't catch it properly.
+      (cons 'subprocess-buffer-size 20) ;; 20MB
       ;; Timeout in seconds after which an in-progress gateway login will be killed.
       (cons 'backend-login-timeout         30)
       ;; Whether or not the system is running tests,

--- a/src/collects/seashell/backend/dispatch.rkt
+++ b/src/collects/seashell/backend/dispatch.rkt
@@ -109,7 +109,9 @@
             (program-destroy-handle pid)]
            [(and result (list pid test-name (and test-res (or "timeout" "killed" "passed")) stdout stderr))
             (send-message connection `#hash((id . -4) (success . #t)
-                                            (result . #hash((pid . ,pid) (test_name . ,test-name) (result . ,test-res)))))]
+                                            (result . #hash((pid . ,pid) (test_name . ,test-name) (result . ,test-res)
+                                                                         (stdout . ,(bytes->string/utf-8 stdout #\?))
+                                                                         (stderr . ,(bytes->string/utf-8 stderr #\?))))))]
            [(list pid test-name "error" exit-code stderr stdout asan-output)
             (send-message connection `#hash((id . -4) (success . #t)
                                            (result . #hash((pid . ,pid) (test_name . ,test-name) (result . "error")
@@ -137,7 +139,10 @@
                                                               diff))
                                                            (stdout . ,(bytes->string/utf-8 stdout #\?))
                                                            (stderr . ,(bytes->string/utf-8 stderr #\?))
-                                                           (asan_output . ,(bytes->string/utf-8 asan-output #\?))))))])))))
+                                                           (asan_output . ,(bytes->string/utf-8 asan-output #\?))))))]
+           [unmatched-result
+            (logf 'error "Unmatched test result: ~a" unmatched-result)
+            (send-message connection `#hash((id . -4) (success . #f) (result . "backend error")))])))))
 
   ;; (project-output-runner-thread)
   ;; Helper thread for dealing with output from running

--- a/src/frontend/frontend/file.js
+++ b/src/frontend/frontend/file.js
@@ -565,6 +565,7 @@ angular.module('frontend-app')
           });
           self.console.running = false;
           self.console.PIDs = null;
+          self.console.stopTestingProgressNote();
           return p;
         };
 


### PR DESCRIPTION
This pull request fixes the problem where if the student's program times out or is killed, stdout and stderr output up until that point are NOT displayed to the student. With this pull request, when a timeout or kill action occurs, stdout and stderr contents will be displayed, up to a certain length ('max-output-bytes-to-keep setting, set to 10,000 bytes).

The problem was caused by 2 different things:

1. There wasn't any backend code at all to send output to the front end when timeouts or kill occurs. Adding the code is pretty simple (similar to the "pass" and "fail" cases).
2. If students have an infinite loop that prints output, it will make the internal pipes consume a ton of memory. This causes the ```call-with-limits``` resource limits to trigger in dispatch.rkt. It turns out that in Racket, threads inside ```call-with-limits```'s thunk are subject to the resource limits, but they do NOT trigger the ```exn:fail:resource?``` exception when exceeding those limits. To fix this problem, I make the internal pipes store at most 'subprocess-buffer-size MBs of data (a config setting set to 20MB). Any output from the student's program beyond this 20MB is thrown away (we won't send more than 10,000 bytes to the frontend anyways).

This pull request also has some frontend Javascript code that will print out the message "Still testing. N tests left...." every 8 seconds. I added this because it might be confusing for students to stare at a blank console for 30 seconds waiting for a timeout. I can remove this code if you want. We can add a proper progress-bar-like thing later; this is a quick hack in the meantime.