### PR TITLE
Prevent students from using offline mode. This was requested by CS136…

### DIFF
--- a/src/frontend/frontend/templates/settings-template.html
+++ b/src/frontend/frontend/templates/settings-template.html
@@ -59,11 +59,11 @@
         Disabled
       </label>
       <label class="radio-inline">
-        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="1">
+        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="1" disabled>
         Enabled
       </label>
       <label class="radio-inline">
-        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="2">
+        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="2" disabled>
         Forced
       </label>
 </div>


### PR DESCRIPTION
In the CS136 course meeting on March 17, 2017, the CS136 instructors agreed that they would like the radio buttons for using offline mode to be disabled. This pull request does this.