### PR TITLE
Hook up most of online I/O callbacks

### DIFF
--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -7,6 +7,7 @@ import {AbstractStorage,
         basename} from "../Storage/Interface";
 import {groupBy} from "../utils";
 import {DispatchFunction} from "../Services";
+import {CompilerError} from "../Errors";
 
 export {AbstractCompiler,
         CompilerResult,
@@ -167,12 +168,4 @@ interface TestMessage {
   test_name: string;
   diff?: DiffLine[];
   asan_output?: string;
-}
-
-class CompilerError extends Error {
-  data: Object;
-  constructor(msg: string, data?: Object) {
-    super(msg);
-    this.data = data;
-  }
 }

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -86,10 +86,6 @@ abstract class AbstractCompiler {
       this.stderr = "";
       this.output("Program finished with exit code " + result.status + ".\n");
       this.programDone(result.pid);
-      this.dispatch({
-        type: "programDone",
-        payload: null
-      });
     }
   }
 
@@ -122,6 +118,7 @@ abstract class AbstractCompiler {
       output += "Produced errors (stderr):\n";
       output += result.stderr;
     }
+    this.programDone(result.pid);
     this.output(output);
   }
 }

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -64,33 +64,70 @@ abstract class AbstractCompiler {
     });
   }
 
+  private outputASAN(ASAN: ASANOutput): string {
+    if (ASAN.error_type === "unknown" && ASAN.raw_message === "")
+      return "";
+    let output = "";
+    output += "Memory error occurred! Type of error: " + ASAN.error_type + "\n";
+    if (ASAN.call_stacks.length === 0) {
+      // If no call stack was sent back, fall back to showing the raw ASAN output
+      output += "Raw error message:\n";
+      output += ASAN.raw_message;
+    }
+    for (let stack = 0; stack < ASAN.call_stacks.length; stack++) {
+      const framelist = ASAN.call_stacks[stack].framelist;
+      const fmisc = ASAN.call_stacks[stack].misc;
+      const indent = framelist.length <= 1 ? "\t" : "\t  ";
+      for (let frame = 0; frame < framelist.length; frame++) {
+        output += indent + "frame " + framelist[frame].frame + ":" +
+          " function " + framelist[frame].function +
+          " in line " + framelist[frame].line +
+          ("column" in framelist[frame] ? ", column " + framelist[frame].column : "") + "\n";
+      }
+      for (let key in fmisc) {
+        output += "\t" + key.replace(/_/g, " ") + ": " + fmisc[key] + "\n";
+      }
+    }
+    for (let key in ASAN.misc) {
+      output += key.replace(/_/g, " ") + ": " + ASAN.misc[key] + "\n";
+    }
+    return output;
+  }
+
   protected handleIO(result: IOMessage): void {
+    let output = "";
     if (result.type === "stdout") {
       this.stdout += result.message;
       const spl = this.stdout.split("\n");
       for (let i = 0; i < spl.length - 1; i++) {
-        this.output(spl[i] + "\n");
+        output += spl[i] + "\n";
       }
       this.stdout = spl[spl.length - 1];
     } else if (result.type === "stderr") {
       this.stderr += result.message;
       const spl = this.stderr.split("\n");
       for (let i = 0; i < spl.length - 1; i++) {
-        this.output(spl[i] + "\n");
+        output += spl[i] + "\n";
       }
       this.stderr = spl[spl.length - 1];
     } else if (result.type === "done") {
-      this.output(this.stdout);
-      this.output(this.stderr);
+      output += this.stdout;
+      output += this.stderr;
       this.stdout = "";
       this.stderr = "";
-      this.output("Program finished with exit code " + result.status + ".\n");
+      const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
+      if (ASAN) {
+        output += this.outputASAN(ASAN);
+      }
+      output += "Program finished with exit code " + result.status + ".\n";
       this.programDone(result.pid);
     }
+    this.output(output);
   }
 
   protected handleTest(result: TestMessage): void {
     let output = "";
+    const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
     if (result.result === "passed") {
       output += "-------------------------------\n";
       output += "Test \"" + result.test_name + "\" passed.\n";
@@ -117,6 +154,10 @@ abstract class AbstractCompiler {
       output += "---\n";
       output += "Produced errors (stderr):\n";
       output += result.stderr;
+    }
+    if (ASAN) {
+      output += "AddressSanitizer Output:\n";
+      output += this.outputASAN(ASAN);
     }
     this.programDone(result.pid);
     this.output(output);
@@ -153,6 +194,7 @@ interface IOMessage {
   pid: number;
   type: string;
   status?: number;
+  asan_output?: string;
 }
 
 type DiffLine = string | [boolean, string];
@@ -165,4 +207,25 @@ interface TestMessage {
   test_name: string;
   diff?: DiffLine[];
   asan_output?: string;
+}
+
+interface ASANOutput {
+  call_stacks: ASANCallStack[];
+  misc: {[type: string]: string};
+  raw_message: string;
+  error_type: string;
+}
+
+interface ASANCallStack {
+  framelist: ASANStackFrame[];
+  misc: {[type: string]: string};
+}
+
+interface ASANStackFrame {
+  file: string;
+  function: string;
+  line: number;
+  column: number;
+  offset: string;
+  frame: number;
 }

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -8,16 +8,24 @@ import {AbstractStorage,
 import {groupBy} from "../utils";
 import {DispatchFunction} from "../Services";
 import {CompilerError} from "../Errors";
+import {OutputBuffer} from "./OutputBuffer";
 
 export {AbstractCompiler,
         CompilerResult,
         CompilerMessage,
         TestBrief,
         Test,
-        CompilerError};
+        CompilerError,
+        IOMessage,
+        TestMessage,
+        DiffLine,
+        ASANOutput};
 
 abstract class AbstractCompiler {
-  constructor(protected storage: AbstractStorage, protected dispatch: DispatchFunction) { }
+
+  constructor(protected storage: AbstractStorage, protected dispatch: DispatchFunction) {
+    this.buffer = new OutputBuffer(dispatch);
+  }
 
   // Outward-facing Compiler interface
   public abstract async compileAndRunProject(proj: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult>;
@@ -28,9 +36,7 @@ abstract class AbstractCompiler {
 
   protected abstract programDone(pid: number): void;
 
-  private stdout: string;
-  private stderr: string;
-  private timeout: any;
+  private buffer: OutputBuffer;
 
   // Function used by both compilers to group the test files appropriately
   //  to send to their respective backends
@@ -58,124 +64,16 @@ abstract class AbstractCompiler {
     });
   }
 
-  private output(out: string): void {
-    this.dispatch({
-      type: "output",
-      payload: out
-    });
-  }
-
-  private flush(): void {
-    this.output(this.stdout + this.stderr);
-    this.stdout = "";
-    this.stderr = "";
-  }
-
-  private outputASAN(ASAN: ASANOutput): string {
-    if (ASAN.error_type === "unknown" && ASAN.raw_message === "")
-      return "";
-    let output = "";
-    output += "Memory error occurred! Type of error: " + ASAN.error_type + "\n";
-    if (ASAN.call_stacks.length === 0) {
-      // If no call stack was sent back, fall back to showing the raw ASAN output
-      output += "Raw error message:\n";
-      output += ASAN.raw_message;
-    }
-    for (let stack = 0; stack < ASAN.call_stacks.length; stack++) {
-      const framelist = ASAN.call_stacks[stack].framelist;
-      const fmisc = ASAN.call_stacks[stack].misc;
-      const indent = framelist.length <= 1 ? "\t" : "\t  ";
-      for (let frame = 0; frame < framelist.length; frame++) {
-        output += indent + "frame " + framelist[frame].frame + ":" +
-          " function " + framelist[frame].function +
-          " in line " + framelist[frame].line +
-          ("column" in framelist[frame] ? ", column " + framelist[frame].column : "") + "\n";
-      }
-      for (let key in fmisc) {
-        output += "\t" + key.replace(/_/g, " ") + ": " + fmisc[key] + "\n";
-      }
-    }
-    for (let key in ASAN.misc) {
-      output += key.replace(/_/g, " ") + ": " + ASAN.misc[key] + "\n";
-    }
-    return output;
-  }
-
   protected handleIO(result: IOMessage): void {
-    let output = "";
-    if (result.type === "stdout") {
-      this.stdout += result.message;
-      const spl = this.stdout.split("\n");
-      for (let i = 0; i < spl.length - 1; i++) {
-        output += spl[i] + "\n";
-      }
-      this.stdout = spl[spl.length - 1];
-    } else if (result.type === "stderr") {
-      this.stderr += result.message;
-      const spl = this.stderr.split("\n");
-      for (let i = 0; i < spl.length - 1; i++) {
-        output += spl[i] + "\n";
-      }
-      this.stderr = spl[spl.length - 1];
-    } else if (result.type === "done") {
-      this.flush();
-      const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
-      if (ASAN) {
-        output += this.outputASAN(ASAN);
-      }
-      output += "Program finished with exit code " + result.status + ".\n";
+    this.buffer.outputIO(result);
+    if (result.type === "done") {
       this.programDone(result.pid);
     }
-    this.output(output);
-    clearTimeout(this.timeout);
-    this.timeout = setTimeout(this.flush, 100);
   }
 
   protected handleTest(result: TestMessage): void {
-    let output = "----------------------------------\n";
-    const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
-    if (result.result === "passed") {
-      output += "Test \"" + result.test_name + "\" passed.\n";
-    } else if (result.result === "failed") {
-      output += "Test \"" + result.test_name + "\" failed.\n";
-      output += "Produced output (stdout):\n";
-      output += result.stdout;
-      output += "Expected output (stdout):\n";
-      const diffStr = (ln: DiffLine): string => {
-        if (typeof ln === "string") {
-          return ln;
-        } else {
-          return ln[1];
-        }
-      };
-      if (result.diff.length > 0) {
-        output += diffStr(result.diff[0]);
-      }
-      for (let i = 1; i < result.diff.length; i++) {
-        output += "\n" + diffStr(result.diff[i]);
-      }
-    } else if (result.result === "error") {
-      output += "Test \"${result.test_name}\" caused an error (with return code ${result.status})!\n";
-      output += "Produced output (stdout):\n";
-      output += result.stdout;
-    } else if (result.result === "no-expect") {
-      output += "Test \"${result.test_name}\" produced output (stdout):\n";
-      output += result.stdout;
-    } else if (result.result === "timeout") {
-      output += "Test \"${result.test_name}\" timed out.\n";
-    } else if (result.result === "killed") {
-      output += "Test \"${result.test_name}\" was killed.\n";
-    };
-    if (result.stderr !== "") {
-      output += "Produced errors (stderr):\n";
-      output += result.stderr;
-    }
-    if (ASAN && ASAN.raw_message !== "") {
-      output += "AddressSanitizer Output:\n";
-      output += this.outputASAN(ASAN);
-    }
+    this.buffer.outputTest(result);
     this.programDone(result.pid);
-    this.output(output);
   }
 }
 

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -38,7 +38,7 @@ abstract class AbstractCompiler {
       return f.name.startsWith(question + "/tests/");
     }), (f: FileBrief) => {
       return basename(f);
-    }).map((t: FileBrief[])=> {
+    }).map((t: FileBrief[]) => {
       let test: TestBrief = {
         name: basename(t[0]),
         in: null,
@@ -67,14 +67,14 @@ abstract class AbstractCompiler {
     if (result.type === "stdout") {
       this.stdout += result.message;
       const spl = this.stdout.split("\n");
-      for (let i=0; i<spl.length-1; i++) {
+      for (let i = 0; i < spl.length - 1; i++) {
         this.output(spl[i] + "\n");
       }
       this.stdout = spl[spl.length - 1];
     } else if (result.type === "stderr") {
       this.stderr += result.message;
       const spl = this.stderr.split("\n");
-      for (let i=0; i<spl.length-1; i++) {
+      for (let i = 0; i < spl.length - 1; i++) {
         this.output(spl[i] + "\n");
       }
       this.stderr = spl[spl.length - 1];
@@ -105,7 +105,7 @@ abstract class AbstractCompiler {
       output += "---\n";
       output += "Expected output (stdout):\n";
       const diffStr = (ln: DiffLine): string => {
-        if(typeof ln === "string") {
+        if (typeof ln === "string") {
           return ln;
         } else {
           return ln[1];
@@ -114,7 +114,7 @@ abstract class AbstractCompiler {
       if (result.diff.length > 0) {
         output += diffStr(result.diff[0]);
       }
-      for (let i=1; i<result.diff.length; i++) {
+      for (let i = 1; i < result.diff.length; i++) {
         output += "\n" + diffStr(result.diff[i]);
       }
       output += "---\n";

--- a/src/frontend/src/helpers/Compiler/Interface.ts
+++ b/src/frontend/src/helpers/Compiler/Interface.ts
@@ -25,6 +25,11 @@ abstract class AbstractCompiler {
   public abstract async programInput(contents: string): Promise<void>;
   // End public interface
 
+  protected abstract programDone(pid: number): void;
+
+  private stdout: string;
+  private stderr: string;
+
   // Function used by both compilers to group the test files appropriately
   //  to send to their respective backends
   protected async getTestsForQuestion(project: ProjectID, question: string): Promise<TestBrief[]> {
@@ -49,6 +54,74 @@ abstract class AbstractCompiler {
         test.expect = t[1];
       return test;
     });
+  }
+
+  private output(out: string): void {
+    this.dispatch({
+      type: "output",
+      payload: out
+    });
+  }
+
+  protected handleIO(result: IOMessage): void {
+    if (result.type === "stdout") {
+      this.stdout += result.message;
+      const spl = this.stdout.split("\n");
+      for (let i=0; i<spl.length-1; i++) {
+        this.output(spl[i] + "\n");
+      }
+      this.stdout = spl[spl.length - 1];
+    } else if (result.type === "stderr") {
+      this.stderr += result.message;
+      const spl = this.stderr.split("\n");
+      for (let i=0; i<spl.length-1; i++) {
+        this.output(spl[i] + "\n");
+      }
+      this.stderr = spl[spl.length - 1];
+    } else if (result.type === "done") {
+      this.output(this.stdout);
+      this.output(this.stderr);
+      this.stdout = "";
+      this.stderr = "";
+      this.output("Program finished with exit code " + result.status + ".\n");
+      this.programDone(result.pid);
+      this.dispatch({
+        type: "programDone",
+        payload: null
+      });
+    }
+  }
+
+  protected handleTest(result: TestMessage): void {
+    let output = "";
+    if (result.result === "passed") {
+      output += "-------------------------------\n";
+      output += "Test \"" + result.test_name + "\" passed.\n";
+    } else if (result.result === "failed") {
+      output += "-------------------------------\n";
+      output += "Test \"" + result.test_name + "\" failed.\n";
+      output += "Produced output (stdout):\n";
+      output += result.stdout;
+      output += "---\n";
+      output += "Expected output (stdout):\n";
+      const diffStr = (ln: DiffLine): string => {
+        if(typeof ln === "string") {
+          return ln;
+        } else {
+          return ln[1];
+        }
+      };
+      if (result.diff.length > 0) {
+        output += diffStr(result.diff[0]);
+      }
+      for (let i=1; i<result.diff.length; i++) {
+        output += "\n" + diffStr(result.diff[i]);
+      }
+      output += "---\n";
+      output += "Produced errors (stderr):\n";
+      output += result.stderr;
+    }
+    this.output(output);
   }
 }
 
@@ -75,6 +148,25 @@ interface CompilerMessage {
   line: number;
   column: number;
   message: string;
+}
+
+interface IOMessage {
+  message: string;
+  pid: number;
+  type: string;
+  status?: number;
+}
+
+type DiffLine = string | [boolean, string];
+
+interface TestMessage {
+  pid: number;
+  result: string;
+  stderr: string;
+  stdout: string;
+  test_name: string;
+  diff?: DiffLine[];
+  asan_output?: string;
 }
 
 class CompilerError extends Error {

--- a/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OfflineCompiler.ts
@@ -27,4 +27,6 @@ class OfflineCompiler extends AbstractCompiler {
   public async programInput(contents: string): Promise<void> { }
 
   public async sendEOF(): Promise<void> { }
+
+  protected programDone(pid: number): void { }
 }

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -105,7 +105,7 @@ class OnlineCompiler extends AbstractCompiler {
   }
 
   protected programDone(pid: number) {
-    if(this.activePIDs.length === 0 || this.activePIDs[0] !== pid) {
+    if (this.activePIDs.length === 0 || this.activePIDs[0] !== pid) {
       throw new CompilerError("Program that was not running has ended.");
     } else {
       this.activePIDs = [];

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -24,6 +24,9 @@ class OnlineCompiler extends AbstractCompiler {
     this.socket = socket;
     this.offlineCompiler = offComp;
     this.activePIDs = [];
+
+    this.socket.register_callback("io", this.handleIO);
+    this.socket.register_callback("test", this.handleTest);
   }
 
   public async compileAndRunProject(proj: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult> {
@@ -99,5 +102,13 @@ class OnlineCompiler extends AbstractCompiler {
       type: "sendEOF",
       pid: this.activePIDs[0]
     });
+  }
+
+  protected programDone(pid: number) {
+    if(this.activePIDs.length === 0 || this.activePIDs[0] !== pid) {
+      throw new CompilerError("Program that was not running has ended.");
+    } else {
+      this.activePIDs = [];
+    }
   }
 }

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -105,10 +105,18 @@ class OnlineCompiler extends AbstractCompiler {
   }
 
   protected programDone(pid: number) {
-    if (this.activePIDs.length === 0 || this.activePIDs[0] !== pid) {
+    const ind = this.activePIDs.indexOf(pid);
+    if (ind === -1) {
       throw new CompilerError("Program that was not running has ended.");
     } else {
-      this.activePIDs = [];
+      this.activePIDs = this.activePIDs.splice(ind, 1);
+    }
+    // if everything has finished running, notify frontend
+    if (this.activePIDs.length === 0) {
+      this.dispatch({
+        type: "programDone",
+        payload: null
+      });
     }
   }
 }

--- a/src/frontend/src/helpers/Compiler/OutputBuffer.ts
+++ b/src/frontend/src/helpers/Compiler/OutputBuffer.ts
@@ -96,8 +96,20 @@ class OutputBuffer {
       output += "Test \"" + result.test_name + "\" passed.\n";
     } else if (result.result === "failed") {
       output += "Test \"" + result.test_name + "\" failed.\n";
+    } else if (result.result === "error") {
+      output += "Test \"${result.test_name}\" caused an error (with return code ${result.status})!\n";
+    } else if (result.result === "no-expect") {
+      output += "Test \"${result.test_name}\" completed.\n";
+    } else if (result.result === "timeout") {
+      output += "Test \"${result.test_name}\" timed out.\n";
+    } else if (result.result === "killed") {
+      output += "Test \"${result.test_name}\" was killed.\n";
+    };
+    if (result.result !== "passed") {
       output += "Produced output (stdout):\n";
       output += result.stdout;
+    }
+    if (result.result === "failed") {
       output += "Expected output (stdout):\n";
       const diffStr = (ln: DiffLine): string => {
         if (typeof ln === "string") {
@@ -112,18 +124,7 @@ class OutputBuffer {
       for (let i = 1; i < result.diff.length; i++) {
         output += "\n" + diffStr(result.diff[i]);
       }
-    } else if (result.result === "error") {
-      output += "Test \"${result.test_name}\" caused an error (with return code ${result.status})!\n";
-      output += "Produced output (stdout):\n";
-      output += result.stdout;
-    } else if (result.result === "no-expect") {
-      output += "Test \"${result.test_name}\" produced output (stdout):\n";
-      output += result.stdout;
-    } else if (result.result === "timeout") {
-      output += "Test \"${result.test_name}\" timed out.\n";
-    } else if (result.result === "killed") {
-      output += "Test \"${result.test_name}\" was killed.\n";
-    };
+    }
     if (result.stderr !== "") {
       output += "Produced errors (stderr):\n";
       output += result.stderr;

--- a/src/frontend/src/helpers/Compiler/OutputBuffer.ts
+++ b/src/frontend/src/helpers/Compiler/OutputBuffer.ts
@@ -1,0 +1,138 @@
+import {IOMessage,
+        TestMessage,
+        DiffLine,
+        ASANOutput} from "./Interface";
+import {DispatchFunction} from "../Services";
+
+export {OutputBuffer};
+
+class OutputBuffer {
+
+  private stdout: string;
+  private stderr: string;
+  private timeout: any;
+
+  constructor(private dispatch: DispatchFunction) {
+    this.stdout = "";
+    this.stderr = "";
+  }
+
+  private output(out: string): void {
+    this.dispatch({
+      type: "output",
+      payload: out
+    });
+  }
+
+  private flush(): void {
+    this.output(this.stdout + this.stderr);
+    this.stdout = "";
+    this.stderr = "";
+  }
+
+  private outputASAN(ASAN: ASANOutput): string {
+    if (ASAN.error_type === "unknown" && ASAN.raw_message === "")
+      return "";
+    let output = "";
+    output += "Memory error occurred! Type of error: " + ASAN.error_type + "\n";
+    if (ASAN.call_stacks.length === 0) {
+      // If no call stack was sent back, fall back to showing the raw ASAN output
+      output += "Raw error message:\n";
+      output += ASAN.raw_message;
+    }
+    for (let stack = 0; stack < ASAN.call_stacks.length; stack++) {
+      const framelist = ASAN.call_stacks[stack].framelist;
+      const fmisc = ASAN.call_stacks[stack].misc;
+      const indent = framelist.length <= 1 ? "\t" : "\t  ";
+      for (let frame = 0; frame < framelist.length; frame++) {
+        output += indent + "frame " + framelist[frame].frame + ":" +
+          " function " + framelist[frame].function +
+          " in line " + framelist[frame].line +
+          ("column" in framelist[frame] ? ", column " + framelist[frame].column : "") + "\n";
+      }
+      for (let key in fmisc) {
+        output += "\t" + key.replace(/_/g, " ") + ": " + fmisc[key] + "\n";
+      }
+    }
+    for (let key in ASAN.misc) {
+      output += key.replace(/_/g, " ") + ": " + ASAN.misc[key] + "\n";
+    }
+    return output;
+  }
+
+  public outputIO(result: IOMessage): void {
+    let output = "";
+    if (result.type === "stdout") {
+      this.stdout += result.message;
+      const spl = this.stdout.split("\n");
+      for (let i = 0; i < spl.length - 1; i++) {
+        output += spl[i] + "\n";
+      }
+      this.stdout = spl[spl.length - 1];
+    } else if (result.type === "stderr") {
+      this.stderr += result.message;
+      const spl = this.stderr.split("\n");
+      for (let i = 0; i < spl.length - 1; i++) {
+        output += spl[i] + "\n";
+      }
+      this.stderr = spl[spl.length - 1];
+    } else if (result.type === "done") {
+      this.flush();
+      const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
+      if (ASAN) {
+        output += this.outputASAN(ASAN);
+      }
+      output += "Program finished with exit code " + result.status + ".\n";
+    }
+    this.output(output);
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(this.flush, 100);
+  }
+
+  public outputTest(result: TestMessage): void {
+    let output = "----------------------------------\n";
+    const ASAN = result.asan_output ? JSON.parse(result.asan_output) : false;
+    if (result.result === "passed") {
+      output += "Test \"" + result.test_name + "\" passed.\n";
+    } else if (result.result === "failed") {
+      output += "Test \"" + result.test_name + "\" failed.\n";
+      output += "Produced output (stdout):\n";
+      output += result.stdout;
+      output += "Expected output (stdout):\n";
+      const diffStr = (ln: DiffLine): string => {
+        if (typeof ln === "string") {
+          return ln;
+        } else {
+          return ln[1];
+        }
+      };
+      if (result.diff.length > 0) {
+        output += diffStr(result.diff[0]);
+      }
+      for (let i = 1; i < result.diff.length; i++) {
+        output += "\n" + diffStr(result.diff[i]);
+      }
+    } else if (result.result === "error") {
+      output += "Test \"${result.test_name}\" caused an error (with return code ${result.status})!\n";
+      output += "Produced output (stdout):\n";
+      output += result.stdout;
+    } else if (result.result === "no-expect") {
+      output += "Test \"${result.test_name}\" produced output (stdout):\n";
+      output += result.stdout;
+    } else if (result.result === "timeout") {
+      output += "Test \"${result.test_name}\" timed out.\n";
+    } else if (result.result === "killed") {
+      output += "Test \"${result.test_name}\" was killed.\n";
+    };
+    if (result.stderr !== "") {
+      output += "Produced errors (stderr):\n";
+      output += result.stderr;
+    }
+    if (ASAN && ASAN.raw_message !== "") {
+      output += "AddressSanitizer Output:\n";
+      output += this.outputASAN(ASAN);
+    }
+    this.output(output);
+  }
+
+}

--- a/src/frontend/src/helpers/Errors.ts
+++ b/src/frontend/src/helpers/Errors.ts
@@ -1,6 +1,8 @@
 export {LoginError,
         GenericError,
-        SyncError}
+        SyncError,
+        WebsocketError,
+        CompilerError};
 
 class GenericError extends Error {
   __proto__: Error;
@@ -22,6 +24,20 @@ class LoginError extends GenericError {
 
 class SyncError extends GenericError {
   constructor(message: string) {
+    super(message);
+  }
+}
+
+class WebsocketError extends GenericError {
+  constructor(message: string,
+              public data?: Object) {
+    super(message);
+  }
+}
+
+class CompilerError extends GenericError {
+  constructor(message: string,
+              public data?: Object) {
     super(message);
   }
 }

--- a/src/frontend/src/helpers/Websocket/WebsocketClient.ts
+++ b/src/frontend/src/helpers/Websocket/WebsocketClient.ts
@@ -2,7 +2,9 @@ import {Coder, ShittyCoder} from "./Crypto";
 import {Connection} from "../Services";
 import WebCrypto = require("node-webcrypto-ossl");
 
-export {WebsocketResult, SeashellWebsocket, WebsocketError};
+export {WebsocketResult,
+        SeashellWebsocket,
+        WebsocketError};
 
 class WebsocketError extends Error {
   data: Object;

--- a/src/frontend/src/helpers/Websocket/WebsocketClient.ts
+++ b/src/frontend/src/helpers/Websocket/WebsocketClient.ts
@@ -1,18 +1,11 @@
 import {Coder, ShittyCoder} from "./Crypto";
 import {Connection} from "../Services";
+import {WebsocketError} from "../Errors";
 import WebCrypto = require("node-webcrypto-ossl");
 
 export {WebsocketResult,
         SeashellWebsocket,
         WebsocketError};
-
-class WebsocketError extends Error {
-  data: Object;
-  constructor(msg: string, d?: Object) {
-    super(msg);
-    this.data = d;
-  }
-}
 
 interface Message {
   [index: string]: any;

--- a/src/frontend/src/helpers/utils.ts
+++ b/src/frontend/src/helpers/utils.ts
@@ -1,13 +1,13 @@
 import {mergeWith} from "ramda";
 export const mergeBetter: any = (a: any, b: any) => (typeof a === "object" && typeof b === "object") ? mergeWith(mergeBetter, a, b) : b;
-export const groupBy = (lst: any[], grp: (a: any)=>any) => {
-  const hash = lst.reduce((acc: any, item: any)=> {
+export const groupBy = (lst: any[], grp: (a: any) => any) => {
+  const hash = lst.reduce((acc: any, item: any) => {
     const k = grp(item);
-    if(!acc[k]) acc[k] = [];
+    if (!acc[k]) acc[k] = [];
     acc[k].push(item);
   }, []);
   let result = [];
-  for(const k in hash) {
+  for (const k in hash) {
     result.push(hash[k]);
   }
   return result;


### PR DESCRIPTION
Not all of the cases are implemented yet but the most common stuff is there, and it shows the general structure of how we're implementing this. The idea I have in mind is: there are two action types that the compiler can send to the dispatch, "output" and "programDone". Output's payload is simply a string, programDone has a null payload, just meant to notify when the program is no longer running. All of the other processing of output will be done by the Compiler class (I may consider abstracting the processing of output into a separate class). The output sent to the dispatch function will be the final data that should be printed directly to the console.