### PR TITLE
Use typescript 2.3 and make backend logs quieter when in debug/development mode

### DIFF
--- a/src/collects/seashell/backend/dispatch.rkt
+++ b/src/collects/seashell/backend/dispatch.rkt
@@ -719,8 +719,9 @@
        `#hash((id . -2) (result . ,(format "Bad message: ~s" message)))]
       [else
        (define id (hash-ref message 'id))
-       (logf 'info "Handling message  id=~a, type=~a. Message: ~a"
-             id (hash-ref message 'type "unknown") (any->short-str message 100))
+       (when (not SEASHELL_DEBUG)
+         (logf 'info "Handling message  id=~a, type=~a. Message: ~a"
+             id (hash-ref message 'type "unknown") (any->short-str message 100)))
        (with-handlers
            ([exn:project?
              (lambda (exn)
@@ -779,9 +780,10 @@
               (define message (bytes->jsexpr data))
               (semaphore-post keepalive-sema)
               (define result (handle-message message))
-              (logf 'info "Responding to msg id=~a. Response: ~a"
-                    (hash-ref result 'id "no_id")
-                    (any->short-str (hash-ref result 'result "no_results") 100))
+              (when (not SEASHELL_DEBUG)
+                (logf 'info "Responding to msg id=~a. Response: ~a"
+                      (hash-ref result 'id "no_id")
+                    (any->short-str (hash-ref result 'result "no_results") 100)))
               (send-message connection result))))))
        (main-loop)]))
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -90,7 +90,7 @@
     "ts-jest": "^19.0.0",
     "tslint": "^4.4.2",
     "tslint-loader": "^3.4.2",
-    "typescript": "~2.2.2",
+    "typescript": "~2.3.2",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
     "webpack-archive-plugin": "^3.0.0",


### PR DESCRIPTION
The typescript 2.3 is to fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17459
I kept getting an error with typescript v2.2