### PR TITLE
Initial Sentry integration

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -280,7 +280,7 @@
       ;; This needs to be long enough for a file to compile.
       (cons 'compiler-ttl                  60)
       ;; Sentry logging endpoint (default #f -- disabled)
-      (cons 'sentry-logging                #f)
+      (cons 'sentry-target                 #f)
       )))
   config-hash)
 

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -279,6 +279,8 @@
       ;; Default TTL for the compiler place.
       ;; This needs to be long enough for a file to compile.
       (cons 'compiler-ttl                  60)
+      ;; Sentry logging endpoint (default #f -- disabled)
+      (cons 'sentry-logging                #f)
       )))
   config-hash)
 
@@ -324,7 +326,7 @@
                  [SEASHELL_INSTALLED Boolean]
                  [SEASHELL_INSTALL_PATH String])
   (provide config-refresh! read-config-string read-config-strings read-config-number read-config-boolean read-config-path
-           read-config-integer read-config-optional-path read-config-nonnegative-real
+           read-config-integer read-config-optional-path read-config-nonnegative-real read-config-optional-string
            SEASHELL_VERSION SEASHELL_BRANCH SEASHELL_COMMIT SEASHELL_API_VERSION
            SEASHELL_SOURCE_PATH
            SEASHELL_BUILD_PATH SEASHELL_DEBUG SEASHELL_INSTALLED SEASHELL_INSTALL_PATH)
@@ -334,6 +336,11 @@
     (define result (read-config symbol))
     (cond [(path? result) (some-system-path->string result)]
           [else (cast result String)]))
+  (: read-config-optional-string (-> Symbol (Option String)))
+  (define (read-config-optional-string symbol)
+    (define result (read-config symbol))
+    (cond [(path? result) (some-system-path->string result)]
+          [else (cast result (Option String))]))
   (: read-config-strings (-> Symbol (Listof String)))
   (define (read-config-strings symbol)
     (define result (read-config symbol))

--- a/src/collects/seashell/log.rkt
+++ b/src/collects/seashell/log.rkt
@@ -18,6 +18,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 (require (submod seashell/seashell-config typed)
          "utils/sentry.rkt"
+         "support-native.rkt"
          typed/json)
 (provide logf make-port-logger standard-logger-setup format-stack-trace)
 
@@ -25,6 +26,13 @@
 (define trace-logger (make-logger 'seashell-api-trace logger))
 (define message-logger (make-logger 'seashell logger))
 (define reporter (new sentry-reporter% [opt-dsn (read-config-optional-string 'sentry-target)]))
+(define userid (format "~a@uwaterloo.ca" (seashell_get_username)))
+(define context
+  #{`#hasheq((user .
+   ,#{`#hasheq((id . ,userid)
+               (email . ,userid))
+      :: JSExpr})) :: (HashTable Symbol JSExpr)})
+(send reporter set-context! context)
 
 (define log-ts-str "[~a-~a-~a ~a:~a:~a ~a]")
 

--- a/src/collects/seashell/utils/sentry.rkt
+++ b/src/collects/seashell/utils/sentry.rkt
@@ -23,6 +23,8 @@
          "uuid.rkt")
 (require/typed racket/hash
                [hash-union (-> (HashTable Symbol JSExpr) (HashTable Symbol JSExpr) (HashTable Symbol JSExpr))])
+(provide sentry-reporter%)
+
 (struct exn:fail:sentry exn:fail ())
 
 (: check-present (All (A) (-> String (Option A) A)))

--- a/src/collects/seashell/utils/sentry.rkt
+++ b/src/collects/seashell/utils/sentry.rkt
@@ -144,8 +144,7 @@
       (define header (make-header))
       (thread
        (thunk
-        (copy-port (post-impure-port target (jsexpr->bytes full-packet) `(,header "Content-Type: application/json"))
-                   (current-output-port)))))
+        (close-input-port (post-impure-port target (jsexpr->bytes full-packet) `(,header "Content-Type: application/json"))))))
 
     (: report-exception (-> exn (HashTable Symbol JSExpr) Any))
     (define/public (report-exception exn local-tags)

--- a/src/collects/seashell/utils/sentry.rkt
+++ b/src/collects/seashell/utils/sentry.rkt
@@ -1,0 +1,170 @@
+#lang typed/racket
+;; Typed Racket Sentry bindings;
+;; Copyright (C) 2017 The Seashell Maintainers
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Lesser General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; See also 'ADDITIONAL TERMS' at the end of the included LICENSE file.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+(require typed/json
+         typed/net/url
+         typed/racket/date
+         "typed-json-struct.rkt"
+         "uuid.rkt")
+(require/typed racket/hash
+               [hash-union (-> (HashTable Symbol JSExpr) (HashTable Symbol JSExpr) (HashTable Symbol JSExpr))])
+(struct exn:fail:sentry exn:fail ())
+
+(: check-present (All (A) (-> String (Option A) A)))
+(define (check-present name optional)
+  (if optional optional
+      (raise (exn:fail:sentry (format "Required argument ~a not present!" name)
+                              (current-continuation-marks)))))
+
+(define sentry-auth-with-secret
+  "X-Sentry-Auth: Sentry sentry_version=7, sentry_client=seashell-sentry/1.0, sentry_timestamp=~a, sentry_key=~a, sentry_secret=~a")
+(define sentry-auth-without-secret
+  "X-Sentry-Auth: Sentry sentry_version=7, sentry_client=seashell-sentry/1.0, sentry_timestamp=~a, sentry_key=~a")
+
+(define sentry-reporter%
+  (class object%
+    (init [opt-dsn : (U False String) #f]
+          [tags : (HashTable Symbol JSExpr) (make-immutable-hash)])
+
+    (: _dsn (Option String))
+    (define _dsn opt-dsn)
+
+    (: dsn URL)
+    (define dsn
+      (let ([_dsn opt-dsn])
+        (cond
+          [_dsn (string->url _dsn)]
+          [else (string->url "https://disabled/")])))
+
+    (: scheme String)
+    (define scheme (if opt-dsn (check-present "URL scheme" (url-scheme dsn)) ""))
+
+    (: keys String)
+    (define keys (if opt-dsn (check-present "Sentry keys" (url-user dsn)) ""))
+
+    (: host String)
+    (define host (if opt-dsn (check-present "Sentry host" (url-host dsn)) ""))
+
+    (: id String)
+    (define id
+      (if opt-dsn
+        (let
+          ([_target (url-path dsn)])
+          (if (empty? _target)
+              (raise (exn:fail:sentry "Required argument Sentry ID not present!"
+                     (current-continuation-marks)))
+              (let
+                  ([id (path/param-path (last _target))])
+                (assert id string?))))
+        ""))
+
+    (: target URL)
+    (define target (url scheme #f host #f #t
+                        `(,(path/param "api" '()) ,(path/param id '()) ,(path/param "store" '()) ,(path/param "" '()))
+                        '() #f))
+    (super-new)
+
+    (: get-public-key (-> String))
+    (define (get-public-key)
+      (define result (regexp-match #rx"([^:]+):?([^:]+)?$" keys))
+      (assert result)
+      (assert (second result) string?))
+
+    (: get-secret-key (-> (Option String)))
+    (define (get-secret-key)
+      (define result (regexp-match #rx"([^:]+):?([^:]+)?$" keys))
+      (assert result)
+      (third result))
+
+    (: make-header (-> String))
+    (define (make-header)
+      (define secret (get-secret-key))
+      (if secret
+          (format sentry-auth-with-secret (current-seconds) (get-public-key) (get-secret-key))
+          (format sentry-auth-without-secret (current-seconds) (get-public-key))))
+
+    (: context (Thread-Cellof JSExpr))
+    (define context (make-thread-cell #{(make-immutable-hash) :: JSExpr} #t))
+
+    (: set-context! (-> JSExpr Any))
+    (define/public (set-context! ctx)
+      (thread-cell-set! context ctx))
+
+    (: get-context (-> JSExpr))
+    (define/public (get-context)
+      (thread-cell-ref context))
+
+    (: generate-stack-trace (-> exn JSExpr))
+    (define (generate-stack-trace exn)
+      (define ctx (continuation-mark-set->context (exn-continuation-marks exn)))
+      `#hasheq((frames .
+         ,(for/list : (Listof (HashTable Symbol JSExpr))
+            ([item : (Pairof (U False Symbol) Any) (in-list ctx)])
+            (define name (symbol->string (or (car item) '|<unknown procedure>|)))
+            (define-values (source line column)
+              (let ([loc (cdr item)])
+                (cond
+                  [(srcloc? loc)
+                   (values (format "~a" (or (srcloc-source loc) "<unknown file>"))
+                           (or (srcloc-line loc) 0)
+                           (or (srcloc-column loc) 0))]
+                  [else (values "<unknown file>" 0 0)])))
+            #{`#hasheq((filename . ,source) (function . ,name) (module . ,source)
+                       (lineno . ,line) (colno . ,column)) :: (HashTable Symbol JSExpr)}))))
+
+    (: send-packet (-> String String (HashTable Symbol JSExpr) (HashTable Symbol JSExpr) Any))
+    (define (send-packet culprit message packet local-tags)
+      (define id (uuid-generate))
+      (define timestamp
+        (parameterize ([date-display-format 'iso-8601])
+          (date->string (current-date) #t)))
+      (define partial-packet
+        #{`#hasheq((event_id . ,id)
+                   (culprit . ,culprit)
+                   (timestamp . ,timestamp)
+                   (message . ,message)) :: (HashTable Symbol JSExpr)})
+      (define full-packet (hash-union partial-packet packet))
+      (define header (make-header))
+      (thread
+       (thunk
+        (copy-port (post-impure-port target (jsexpr->bytes full-packet) `(,header "Content-Type: application/json"))
+                   (current-output-port)))))
+
+    (: report-exception (-> exn (HashTable Symbol JSExpr) Any))
+    (define/public (report-exception exn local-tags)
+      (when _dsn
+        (define ctx
+          (let ([_ctx (continuation-mark-set->context (exn-continuation-marks exn))])
+            (if (empty? _ctx) (list (cons '|<no stack frame available>| #f)) _ctx)))
+        (define to-blame (symbol->string (or (car (first ctx)) '|<unknown procedure>|)))
+        (define module
+          (let ([location (cdr (first ctx))])
+            (cond
+              [(srcloc? location)
+               (format "~a" (srcloc-source location))]
+              [else "<unknown source file>"])))
+        (define exception-packet
+          `#hasheq((exception .
+            ,#{`#hasheq((values .
+              ,#{`(,#{`#hasheq((type . ,(assert (second (assert (regexp-match #rx"struct:(.*)"
+                                         (format "~a" (vector-ref (struct->vector exn) 0)))))))
+                       (value . ,(exn-message exn))
+                       (module . ,module)
+                       (stacktrace . ,(generate-stack-trace exn))) :: JSExpr}) :: JSExpr})) :: JSExpr})))
+        (send-packet to-blame (exn-message exn) exception-packet local-tags)))
+))


### PR DESCRIPTION
This pull request adds initial (basic) Sentry integration to Seashell.

What's done:
 - Basic exception reporting + Racket stacktraces.
 - Work to split off log messages from API call traces (we currently log every request made over the websocket).

What's not done:
 - Annotating exception reports with last ~50 or so log messages.