### PR TITLE
[frontend] Implement waitForSync by disconnect/connect.

### DIFF
--- a/src/frontend/src/actions/index.ts
+++ b/src/frontend/src/actions/index.ts
@@ -392,10 +392,9 @@ const mapDispatchToProps = (dispatch: Function) => {
         },
         marmosetSubmit: (project: S.ProjectID, question: string, marmosetProject: string) => {
           return asyncAction(actions.dispatch.file.flushFileBuffer())
-            .then((expectingChange) =>
-              asyncAction(storage().waitForSync(expectingChange)).then(() =>
-                asyncAction(webStorage().marmosetSubmit(project,
-                  marmosetProject, question))));
+                 .then(() => asyncAction(storage().waitForSync()))
+                 .then(() => asyncAction(webStorage().marmosetSubmit(project,
+                        marmosetProject, question)));
         },
         getMarmosetResults: async (marmosetProject: string) => {
           const oldLength = JSON.parse(await asyncAction(webStorage().getTestResults(marmosetProject))).result.length;
@@ -583,7 +582,7 @@ const mapDispatchToProps = (dispatch: Function) => {
           });
           asyncAction(actions.dispatch.file.flushFileBuffer())
             .then((expectingChange) =>
-                asyncAction(storage().waitForSync(expectingChange)).then(() =>
+                asyncAction(storage().waitForSync()).then(() =>
                   asyncAction(Services.compiler().compileAndRunProject(project,
                     question, fid, test)).then((result: C.CompilerResult) => {
                       dispatch({

--- a/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
+++ b/src/frontend/src/helpers/Compiler/OnlineCompiler.ts
@@ -33,6 +33,7 @@ class OnlineCompiler extends AbstractCompiler {
   }
 
   public async compileAndRunProject(pid: ProjectID, question: string, file: FileID, runTests: boolean): Promise<CompilerResult> {
+    console.log("Compiling project -- connection status: %s", this.socket.isConnected() ? "connected" : "not connected");
     if (!this.socket.isConnected()) {
       return this.offlineCompiler.compileAndRunProject(pid, question, file, runTests);
     } else if (this.activePIDs.length > 0) {

--- a/src/frontend/src/helpers/Services.ts
+++ b/src/frontend/src/helpers/Services.ts
@@ -54,7 +54,8 @@ namespace Services {
     debug    = options.debugService || false;
 
     socketClient    = new SeashellWebsocket(options.debugWebSocket);
-    localStorage    = new LocalStorage(options.debugLocalStorage);
+    localStorage    = new LocalStorage(options.debugLocalStorage,
+                                      () => (socketClient as SeashellWebsocket).isConnected());
     webStorage      = new WebStorage(socketClient, localStorage, options.debugWebStorage);
 
     Dexie.Syncable.registerSyncProtocol("seashell",

--- a/src/frontend/src/helpers/Storage/SkeletonManager.ts
+++ b/src/frontend/src/helpers/Storage/SkeletonManager.ts
@@ -159,7 +159,7 @@ class SkeletonManager {
       ));
       // sync afterwards to update the local storage.
       // not ideal, but works for now.
-      await this.storage.waitForSync(true);
+      await this.storage.waitForSync();
     }
   }
 


### PR DESCRIPTION
This PR implements waitForSync by calling disconnect/connect, avoiding the possible race condition that could occur when a write was expected and synced before waitForSync could check.