### PR TITLE
Frontend cleanup, skeleton fixes

### DIFF
--- a/src/frontend/src/actions/index.ts
+++ b/src/frontend/src/actions/index.ts
@@ -392,7 +392,6 @@ const mapDispatchToProps = (dispatch: Function) => {
         },
         marmosetSubmit: (project: S.ProjectID, question: string, marmosetProject: string) => {
           return asyncAction(actions.dispatch.file.flushFileBuffer())
-                 .then(() => asyncAction(storage().waitForSync()))
                  .then(() => asyncAction(webStorage().marmosetSubmit(project,
                         marmosetProject, question)));
         },
@@ -558,7 +557,7 @@ const mapDispatchToProps = (dispatch: Function) => {
         },
         archiveProjects: () => {
           return asyncAction(webStorage().archiveProjects()).then(() =>
-            asyncAction(storage().waitForSync())).then(() => dispatch({
+            dispatch({
               type: appStateActions.redirectHome,
               payload: null
             }));

--- a/src/frontend/src/helpers/Storage/LocalStorage.ts
+++ b/src/frontend/src/helpers/Storage/LocalStorage.ts
@@ -471,6 +471,7 @@ class StorageDB extends Dexie {
         await this.syncable.connect("seashell", "http://no-host.org");
       } catch (e) {
         console.warn("Using stale contents -- waitForSync failed with %s.", e);
+        throw new E.StorageError("Error syncing with the backend -- " + e);
       }
     }
   }

--- a/src/frontend/src/helpers/Storage/SkeletonManager.ts
+++ b/src/frontend/src/helpers/Storage/SkeletonManager.ts
@@ -4,7 +4,6 @@ import {ProjectID,
         Project,
         File} from "./Interface";
 import * as E from "../Errors";
-import * as $ from "jquery";
 
 export {SkeletonManager};
 
@@ -30,12 +29,19 @@ class SkeletonManager {
   private async getUserWhitelist(): Promise<string[]> {
     if (!this.userWhitelist) {
       try {
-        this.userWhitelist = await <PromiseLike<any>>$.get(USER_WHITELIST_URL);
-      } catch (e) {
-        if (this.socket.isConnected()) {
-          throw new E.WebsocketError("Could not load user whitelist file.", e);
+        let result = await fetch(USER_WHITELIST_URL);
+        if (result.ok) {
+          this.userWhitelist = await result.json();
+        } else {
+          throw new E.SkeletonError("Could not load user whitelist file -- " +  result.statusText);
         }
-        return [];
+      } catch (e) {
+        if (e instanceof TypeError) {
+          return [];
+        }
+        else {
+          throw e;
+        }
       }
     }
     return this.userWhitelist || [];
@@ -50,12 +56,17 @@ class SkeletonManager {
   private async getProjectsWithWhitelistSkeletons(): Promise<string[]> {
     if (!this.projectWhitelist) {
       try {
-        this.projectWhitelist = await <PromiseLike<any>>$.get(PROJ_WHITELIST_URL);
-      } catch (e) {
-        if (this.socket.isConnected()) {
-          throw new E.WebsocketError("Could not load project whitelist file.", e);
+        let result = await fetch(PROJ_WHITELIST_URL);
+        if (result.ok) {
+          this.projectWhitelist = await result.json();
+        } else {
+          throw new E.SkeletonError("Could not load project whitelist file -- " + result.statusText);
         }
-        return [];
+      } catch (e) {
+        if (e instanceof TypeError)
+          return [];
+        else
+          throw e;
       }
     }
     return this.projectWhitelist || [];
@@ -64,12 +75,18 @@ class SkeletonManager {
   private async getProjectsWithSkeletons(): Promise<string[]> {
     if (!this.projectsWithSkeletons) {
       try {
-        this.projectsWithSkeletons = await <PromiseLike<any>>$.get(PROJ_SKEL_URL);
-      } catch (e) {
-        if (this.socket.isConnected()) {
-          throw new E.WebsocketError("Could not load project skeleton list.", e);
+        let result = await fetch(PROJ_SKEL_URL);
+        if (result.ok) {
+          this.projectsWithSkeletons = await result.json();
+        } else {
+          throw new E.SkeletonError("Could not load project skeleton file -- " + result.statusText);
         }
-        return [];
+      } catch (e) {
+        if (e instanceof TypeError) {
+          return [];
+        } else {
+          throw e;
+        }
       }
     }
     return this.projectsWithSkeletons || [];

--- a/src/frontend/src/helpers/Storage/SkeletonManager.ts
+++ b/src/frontend/src/helpers/Storage/SkeletonManager.ts
@@ -123,11 +123,16 @@ class SkeletonManager {
         let query = querybuilder.toString();
         let raw = await fetch(`${SKEL_FILE_LIST_URL}?${query}`);
         if (raw.ok) {
-          return (await raw.json()).map(
-            (path: string) => path.replace(new RegExp(`^${project.name}/`), "")
-          ).filter(
-            (path: string) => path.length > 0 && path[path.length - 1] !== "/"
-          ).sort();
+          let result = await raw.json();
+          if (!result.error) {
+            return result.result.map(
+              (path: string) => path.replace(new RegExp(`^${project.name}/`), "")
+            ).filter(
+              (path: string) => path.length > 0 && path[path.length - 1] !== "/"
+            ).sort();
+          } else {
+            throw new E.SkeletonError(`Could not load skeleton files for ${project.name} - ${result.result}.`);
+          }
         } else {
           throw new E.SkeletonError(`Could not load skeleton files for ${project.name}.`);
         }
@@ -145,7 +150,7 @@ class SkeletonManager {
     let [localFileObjList, serverFileList] =
       await Promise.all([this.storage.getFiles(proj), this.listSkeletonFiles(proj)]);
     let localFileList = localFileObjList.map((f: File) => f.name);
-    return serverFileList.filter((f: string) => localFileList.find((g: string) => f === g));
+    return serverFileList.filter((f: string) => !localFileList.find((g: string) => f === g));
   }
 
   private async getSkeletonZipFileURL(pname: string): Promise<string|false> {

--- a/src/frontend/src/helpers/Websocket/WebsocketClient.ts
+++ b/src/frontend/src/helpers/Websocket/WebsocketClient.ts
@@ -301,7 +301,7 @@ class SeashellWebsocket {
     } else if (type === "connected" && this.isConnected() && now) {
       cb();
     }
-    return this.lastCB-1;
+    return this.lastCB - 1;
   }
 
   public unregister_callback(key: number) {

--- a/src/frontend/src/reducers/appStateReducer.ts
+++ b/src/frontend/src/reducers/appStateReducer.ts
@@ -53,7 +53,7 @@ export interface appStateReducerState {
   fileOpTarget?: string;
   conflictContents: S.Contents[];
   projects: S.Project[];
-  marmosetProjects: S.MarmosetProject[];
+  marmosetProjects?: S.MarmosetProject[];
   marmosetInterval: number;
   runState?: number;
   currentProject?: appStateReducerProjectState;
@@ -110,7 +110,7 @@ export default function appStateReducer(state: appStateReducerState = {
     fileOpTarget: undefined,
     conflictContents: [],
     projects: [],
-    marmosetProjects: [],
+    marmosetProjects: undefined,
     marmosetInterval: 0,
     runState: 0,
     currentProject: undefined,

--- a/src/frontend/src/reducers/appStateReducer.ts
+++ b/src/frontend/src/reducers/appStateReducer.ts
@@ -187,9 +187,6 @@ export default function appStateReducer(state: appStateReducerState = {
       state = clone(state);
       if (state.currentProject && state.currentProject.currentQuestion) {
         state.currentProject.currentQuestion.currentFile = undefined;
-      } else {
-        console.warn("Invalid state reached -- currentProject or currentQuestion is undefined in invalidateFile");
-        // throw new Error("Invalid state reached -- currentProject or currentQuestion is undefined in invalidateFile");
       }
       return state;
     case appStateActions.getProjects:

--- a/src/frontend/src/views/Project/Prompt/MarmosetResult.tsx
+++ b/src/frontend/src/views/Project/Prompt/MarmosetResult.tsx
@@ -28,7 +28,7 @@ class MarmosetResult extends React.Component<MarmosetResultProps&actionsInterfac
       this.pid = this.props.appState.currentProject.id;
       this.pname = this.props.appState.currentProject.name;
       this.question = this.props.appState.currentProject.currentQuestion.name;
-      const mproj = this.props.appState.marmosetProjects.find((proj: S.MarmosetProject) =>
+      const mproj = (this.props.appState.marmosetProjects || []).find((proj: S.MarmosetProject) =>
         `${this.pname}${this.question}`.toUpperCase() === proj.project);
       if (mproj) {
         this.matchedProject = mproj.project;
@@ -72,7 +72,7 @@ class MarmosetResult extends React.Component<MarmosetResultProps&actionsInterfac
       <select className="pt-select" disabled={this.state.disabled}
           value={this.state.marmProject} onChange={e =>
             this.setState(merge(this.state, {marmProject: e.currentTarget.value}))}>
-        {this.props.appState.marmosetProjects.map((proj: S.MarmosetProject) =>
+        {(this.props.appState.marmosetProjects || []).map((proj: S.MarmosetProject) =>
           (<option value={proj.project}>{proj.project}</option>))}
       </select>
       <button type="button" className="pt-button" onClick={() => this.submit()}>

--- a/src/frontend/src/views/Project/index.tsx
+++ b/src/frontend/src/views/Project/index.tsx
@@ -56,21 +56,19 @@ class Project extends React.Component<ProjectProps&actionsInterface, ProjectStat
 
   private matchMarmosetProject(project: string, question: string): string {
     const candidate = `${project}${question}`.toUpperCase();
-    const found = this.props.appState.marmosetProjects.find((p: S.MarmosetProject) =>
+    const found = (this.props.appState.marmosetProjects || []).find((p: S.MarmosetProject) =>
       candidate === p.project);
     return found === undefined ? "" : found.project;
   }
 
   generateMarmosetButton(project: appStateReducerProjectState) {
       if (project.currentQuestion) {
-        if (this.props.appState.marmosetProjects.length === 0) {
-          this.props.dispatch.project.getMarmosetProjects();
-        }
         const marmosetDispatch = (async (projectName: string, questionName: string) => {
           this.setState({marmosetResults: {
             open: true,
             result: null
           }});
+          await this.props.dispatch.project.getMarmosetProjects();
           const result = await this.props.dispatch.question.getMarmosetResults(
             this.matchMarmosetProject(projectName, questionName));
           this.setState({marmosetResults: {


### PR DESCRIPTION
This PR cleans up some of the frontend code:
- Most of the JQuery AJAX calls have been replaced with native fetch(...) calls
- The skeleton system works now (will load deleted files) -- although the backend is broken right now (the API call is returning void, and jsexpr->string doesn't like that)
- Some of the Marmoset code is cleaner (still kind of sketchy)

I'm not sure what we want to do with the skeleton system.  We currently cache the entries, although we still invoke the CGI scripts a good few dozen times on first load as all the calls race against each other.  It might be nicer to just drop the local caching and rely on the browser to do the right thing -- in particular, students will no longer need to refresh to fetch new skeletons.