### PR TITLE
[frontend] Block first acceptance on applyRemoteChanges.

### DIFF
--- a/src/frontend/src/helpers/Storage/SyncProtocol.ts
+++ b/src/frontend/src/helpers/Storage/SyncProtocol.ts
@@ -97,12 +97,12 @@ class SyncProtocol { // implements Dexie.Syncable.ISyncProtocol {
     };
 
     let isFirstRound = true;
-    this.change_key = this.socket.register_callback("changes", (request: any) => {
+    this.change_key = this.socket.register_callback("changes", async (request: any) => {
       const changes = /*<Dexie.Syncable.IDatabaseChange[]>*/request.changes.map(deconvertChange);
       const currentRevision = <number>request.currentRevision;
       const partial = <boolean>request.partial;
 
-      applyRemoteChanges(changes, currentRevision, partial);
+      await applyRemoteChanges(changes, currentRevision, partial);
       if (isFirstRound && !partial) {
         onSuccess({
           react: async (changes: any, baseRevision: number, partial: boolean, onChangesAccepted: () => void) => {


### PR DESCRIPTION
This changes the sync protocol to block until the server's changes have been successfully applied.

If there are a large number of changes that need to be synced this can block forever.  I've submitted a PR to Dexie that will hopefully mitigate this issue (it does on the one bad example we have right now).

See https://github.com/dfahlander/Dexie.js/pull/570/ and https://github.com/dfahlander/Dexie.js/issues/569