### PR TITLE
Move ~/.seashell folder to ~/cs136/seashell

### DIFF
--- a/src/backend/user/user-child.c
+++ b/src/backend/user/user-child.c
@@ -75,7 +75,7 @@ int seashell_signal_detach(void) {
    */ 
   int error = 0;
 
-  char *logfd_path = make_message("%s/.seashell/seashell.log", getenv("HOME"));
+  char *logfd_path = make_message("%s/cs136/seashell/seashell.log", getenv("HOME"));
   if (logfd_path == NULL) {
     error = 1;
     goto end;

--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -34,6 +34,8 @@
 (define SEASHELL_LIGHTWEIGHT_LAUNCHERS @SEASHELL_LIGHTWEIGHT_LAUNCHERS@)
 (define SEASHELL_RACKET "@SEASHELL_RACKET@")
 
+(define COURSE "cs136")
+
 ;; (read-config key) takes a symbol? key, and looks it up in the config hash;
 ;; produces the corresponding value, or dies with an error if the key was not
 ;; found
@@ -217,16 +219,18 @@
       ;; via SSH.
       (cons 'host                          '("localhost"))
       ;; Location of per-user configuration directory.
-      (cons 'seashell                      (build-path (find-system-path 'home-dir) ".seashell"))
+      (cons 'seashell                      (build-path (find-system-path 'home-dir) COURSE "seashell"))
+      ;; Location of old per-user configuration directory, for backwards compatibility
+      (cons 'old-seashell                  (build-path (find-system-path 'home-dir) ".seashell"))
       ;; Location of the runtime-files directory.
-      (cons 'runtime-files-path            (build-path (find-system-path 'home-dir) ".seashell" "runtime-files"))
+      (cons 'runtime-files-path            (build-path (find-system-path 'home-dir) COURSE "seashell" "runtime-files"))
       ;; Location to store periodic database backups in filesystem
-      (cons 'export-path                   (build-path (find-system-path 'home-dir) ".seashell" "projects"))
+      (cons 'export-path                   (build-path (find-system-path 'home-dir) COURSE "seashell" "projects"))
       ;; Location of SQLite database file relative to the 'seashell directory
       (cons 'database-file                 "seashell.db")
       ;; Location of the Seashell database for a parameterized user. Used in seashell-cli.
       ;; TODO make sure this is consistent with the above.
-      (cons 'database-file-format          "/u/~a/.seashell/seashell.db")
+      (cons 'database-file-format          (format "/u/~~a/~a/seashell/seashell.db" COURSE))
       ;; Name of credentials file.
       (cons 'seashell-creds-name           (format "seashell~a-creds" @SEASHELL_API_VERSION@))
       ;; Name of credentials cookie
@@ -238,7 +242,7 @@
       ;; Location of the Submit tool
       (cons 'submit-tool                    "/u8/cs_build/bin/marmoset_submit")
       ;; Location of the Marmoset test results script
-      (cons 'test-results-tool              "/u2/cs136/marmoset-scripts/get-test-results/get-test-results")
+      (cons 'test-results-tool              (format "/u/~a/marmoset-scripts/get-test-results/get-test-results" COURSE))
       ;; Location of the default project template
       (cons 'default-project-template       "https://github.com/cs136/seashell-default/archive/v1.0.zip")
       ;; File setting bitmasks
@@ -288,6 +292,8 @@
       (cons 'compiler-ttl                  60)
       ;; Sentry logging endpoint (default #f -- disabled)
       (cons 'sentry-target                 #f)
+      ;; whoami binary (used for CLI)
+      (cons 'whoami                        "/usr/bin/whoami")
       )))
   config-hash)
 

--- a/src/collects/seashell/backend/asan-driver.rkt
+++ b/src/collects/seashell/backend/asan-driver.rkt
@@ -24,4 +24,4 @@
 
 (fprintf stderr "-------------- RESULT -----------------\n")
 
-(printf "~a" (asan->json file-contents (path->string (build-path (find-system-path 'home-dir) ".seashell"))))
+(printf "~a" (asan->json file-contents (path->string (build-path (find-system-path 'home-dir) "cs136" "seashell"))))

--- a/src/collects/seashell/backend/server.rkt
+++ b/src/collects/seashell/backend/server.rkt
@@ -241,8 +241,8 @@
 
     ;; Make sure the seashell.db file has group read and write permissions so that
     ;; course accounts can use seashell-cli
-    (define db-file-path (build-path (read-config-path 'seashell) (read-config-path 'database-file)))
-    (when (file-exists? db-file-path) (file-or-directory-permissions db-file-path #o660)))
+    (define db-file-path (build-path (read-config 'seashell) (read-config 'database-file)))
+    (when (file-exists? db-file-path) (file-or-directory-permissions db-file-path #o660))
 
     ;; Replace stderr with a new port that writes to a log file in the user's Seashell directory.
     (current-error-port (open-output-file (build-path (read-config 'seashell) "seashell.log")


### PR DESCRIPTION
This pull request moves ~/.seashell to ~/cs136/seashell. The reason for doing this is to let course accounts run seashell-cli on student's seashell.db. The ~/cs136/ folder has group cs136 and group rws permissions, and is automatically created based on enrolment data before classes start.