### PR TITLE
Another fix for restoring skeleton files

### DIFF
--- a/src/collects/seashell/backend/dispatch.rkt
+++ b/src/collects/seashell/backend/dispatch.rkt
@@ -374,10 +374,10 @@
       [(hash-table
         ('id id)
         ('type "restoreFileFrom")
-        ('project project)
+        ('project pid)
         ('file file)
         ('template template))
-       (restore-file-from-template project file template)
+       (restore-file-from-template pid file template)
        `#hash((id . ,id)
               (success . #t)
               (result . #t))]

--- a/src/frontend/src/helpers/Storage/SkeletonManager.ts
+++ b/src/frontend/src/helpers/Storage/SkeletonManager.ts
@@ -244,7 +244,7 @@ class SkeletonManager {
       await Promise.all(missingFiles.map(async (f: string) =>
         this.socket.sendMessage({
           type: "restoreFileFrom",
-          project: project.name,
+          project: pid,
           file: f,
           template: await this.getSkeletonZipFileURL(project.name)
         }).catch((e) => {


### PR DESCRIPTION
Looks like the project name was being passed when the project ID was required