### PR TITLE
Old Seashell (v3) Updates:

### DIFF
--- a/src/backend/compiler/compiler.cc
+++ b/src/backend/compiler/compiler.cc
@@ -159,6 +159,9 @@ struct seashell_compiler {
   /** Object files discovered by dependency resolution */
   std::vector<std::string> object_paths;
 
+  /** All source_paths and object_paths joined into one string */
+  std::string dep_paths;
+
   /** Module compilation messages. */
   std::vector<seashell_diag> messages;
 
@@ -537,6 +540,27 @@ extern "C" const char * seashell_compiler_get_object (struct seashell_compiler* 
 #else
 std::string seashell_compiler_get_object(struct seashell_compiler* compiler) {
   return std::string(compiler->output_object.begin(), compiler->output_object.end());
+#endif
+}
+
+#ifndef __EMSCRIPTEN__
+extern "C" const char *seashell_compiler_get_dep_paths(struct seashell_compiler *compiler) {
+#else
+std::string seashell_compiler_get_dep_paths(struct seashell_compiler *compiler) {
+#endif
+  compiler->dep_paths = "";
+  for(int i=0; i<compiler->source_paths.size(); i++) {
+    compiler->dep_paths += compiler->source_paths[i];
+    compiler->dep_paths += " ";
+  }
+  for(int i=0; i<compiler->object_paths.size(); i++) {
+    compiler->dep_paths += compiler->object_paths[i];
+    compiler->dep_paths += " ";
+  }
+#ifndef __EMSCRIPTEN__
+  return compiler->dep_paths.c_str();
+#else
+  return compiler->dep_paths;
 #endif
 }
 

--- a/src/backend/compiler/compiler.h
+++ b/src/backend/compiler/compiler.h
@@ -36,6 +36,7 @@ std::string seashell_compiler_get_diagnostic_message(struct seashell_compiler* c
 std::string seashell_compiler_object_arch(struct seashell_compiler* compiler);
 std::string seashell_compiler_object_os (struct seashell_compiler* compiler);
 std::string seashell_compiler_get_object_dep(struct seashell_compiler *compiler, int k);
+std::string seashell_compiler_get_dep_paths(struct seashell_compiler *compiler);
 #else
 extern "C" const char* seashell_clang_version();
 extern "C" void seashell_compiler_set_main_file(struct seashell_compiler *compiler, const char *file);
@@ -49,6 +50,7 @@ extern "C" const char * seashell_compiler_get_diagnostic_message (struct seashel
 extern "C" const char* seashell_compiler_object_arch (struct seashell_compiler* compiler);
 extern "C" const char* seashell_compiler_object_os (struct seashell_compiler* compiler);
 extern "C" const char *seashell_compiler_get_object_dep(struct seashell_compiler *compiler, int k);
+extern "C" const char *seashell_compiler_get_dep_paths(struct seashell_compiler *compiler);
 #endif
 extern "C" struct seashell_compiler* seashell_compiler_make (void);
 extern "C" void seashell_compiler_free (struct seashell_compiler* compiler);

--- a/src/collects/seashell/compiler/ffi.rkt
+++ b/src/collects/seashell/compiler/ffi.rkt
@@ -40,6 +40,7 @@
            seashell_compiler_get_diagnostic_message
            seashell_compiler_run
            seashell_compiler_get_object
+           seashell_compiler_get_dep_paths
            seashell_clang_version
            seashell_compiler_object_arch
            seashell_compiler_object_os
@@ -99,6 +100,8 @@
                           (memcpy result address size)
                           result]
                         [else #f])))))
+  (define-clang seashell_compiler_get_dep_paths
+                (_fun _seashell_compiler-ptr -> _string/utf-8))
   (define-clang seashell_compiler_get_object_dep_count
                 (_fun _seashell_compiler-ptr -> _int))
   (define-clang seashell_compiler_get_object_dep
@@ -122,6 +125,7 @@
                [seashell_compiler_get_diagnostic_column (-> Seashell-Compiler-Ptr Nonnegative-Integer Index)]
                [seashell_compiler_get_diagnostic_file (-> Seashell-Compiler-Ptr Nonnegative-Integer String)]
                [seashell_compiler_get_diagnostic_message (-> Seashell-Compiler-Ptr Nonnegative-Integer String)]
+               [seashell_compiler_get_dep_paths (-> Seashell-Compiler-Ptr String)]
                [seashell_compiler_run (-> Seashell-Compiler-Ptr Boolean Fixnum)]
                [seashell_compiler_object_arch (-> Seashell-Compiler-Ptr String)]
                [seashell_compiler_object_os (-> Seashell-Compiler-Ptr String)]
@@ -146,6 +150,7 @@
            seashell_compiler_get_diagnostic_message
            seashell_compiler_run
            seashell_compiler_get_object
+           seashell_compiler_get_dep_paths
            seashell_clang_version
            seashell_compiler_object_arch
            seashell_compiler_object_os

--- a/src/frontend/frontend/frontend.js
+++ b/src/frontend/frontend/frontend.js
@@ -111,7 +111,7 @@ angular.module('frontend-app', ['seashell-websocket', 'seashell-projects', 'ngCo
             "Do you wish to logout?  Any unsaved data will be lost.")
             .then(function () {
               $cookies.remove(SEASHELL_CREDS_COOKIE);
-              $window.top.location = "https://cas.uwaterloo.ca/logout";
+              $window.top.location = "https://www.student.cs.uwaterloo.ca/~cs136/seashell-old/"; // "https://cas.uwaterloo.ca/logout";
             });
         };
         // Settings

--- a/src/frontend/frontend/templates/settings-template.html
+++ b/src/frontend/frontend/templates/settings-template.html
@@ -59,11 +59,11 @@
         Disabled
       </label>
       <label class="radio-inline">
-        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="1">
+        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="1" disabled>
         Enabled
       </label>
       <label class="radio-inline">
-        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="2">
+        <input name="offline-mode" type="radio" ng-model="temp.offline_mode" ng-value="2" disabled>
         Forced
       </label>
 </div>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -19,13 +19,19 @@
         <link href="//fonts.googleapis.com/css?family=Unkempt:700" rel="stylesheet" type="text/css">
         <div id="seashell-logo" class="col-md-6 col-xs-6 text-left" style="padding: 0">
           <span style="font-family: 'Unkempt', cursive; font-size: 25px; color: #888">seashell</span>
-          <span style="font-size: 14px; color: black; font-variant: small-caps; color: #888; position: absolute">beta</span>
+          <span style="font-size: 14px; color: black; font-variant: small-caps; color: #888; position: absolute">3.0.4</span>
         </div>
       </div>
     </header>
     <div class="container" ng-controller="LoginController as login">
       <form class="form-signin" role="form" ng-submit="login.login()">
-        <h2 class="form-signing-heading">Please sign in with your student.cs credentials</h2>
+        <h2 class="form-signing-heading">Please sign in with your <a href="https://www.student.cs.uwaterloo.ca/password/">student.cs</a> credentials</h2>
+        <div>Supported browsers:
+          <ul>
+            <li><a href="https://www.mozilla.org/firefox/">Firefox 54 - 57</a></li>
+            <li><a href="https://www.google.com/chrome/">Google Chrome 60 - 62</a></li>
+          </ul>
+        </div>
 
         <input type="text" class="form-control" placeholder="Username" ng-model="login.user" id="user"
           ng-disabled="login.busy" />
@@ -38,7 +44,10 @@
           Logging in...
         </div>
         <div class="alert alert-danger" ng-show="login.error" ng-cloak>
-          {{login.error}}
+          Error message: <b>{{(login.error.responseJSON.error.message === "Invalid credentials." ||
+                               login.error.responseJSON.error.message === "Bad password provided.")
+                               ? "Invalid Username and/or Password" : login.error.responseJSON.error.message}}</b><br>
+          Extra info: {{login.error.status}} {{login.error.statusText}}
         </div>
       </form>
     </div>


### PR DESCRIPTION
 * Hack around issue #836 by using clang executable, which finds the memory leak properly. I gave up trying to diagnose the Seashell wrapper.
 * Log out button should go back to Seashell sign-in page instead of CAS
 * Update sign-in page with supported browsers and better "wrong password" message
 * Disable offline mode

