### PR TITLE
V3 jan2018 updates

### DIFF
--- a/src/collects/seashell-config.rkt.in
+++ b/src/collects/seashell-config.rkt.in
@@ -195,7 +195,12 @@
                                             ;; "-analyzer-checker=core.CallAndMessage,core.StackAddressEscape,core.UndefinedBinaryOperatorResult,unix"))
                                             ))
       ;; Path to the clang binary to use to compile the student's code
-      (cons 'clang-binary-path             (build-path SEASHELL_INSTALL_PATH "bin" "clang-3.9"))
+      (cons 'clang-binary-path             (let
+                                            ([install-path (build-path SEASHELL_INSTALL_PATH "bin" "clang-3.9")]
+                                             [build-path (build-path SEASHELL_BUILD_PATH "lib/llvm/bin/clang-3.9")])
+                                            (if (and (not SEASHELL_INSTALLED) (file-exists? build-path))
+                                              build-path
+                                              install-path)))
       ;; Depth of recursive .h search when compiling
       (cons 'header-search-depth           5)
       ;; Number of seconds a program can run without I/O before timing out

--- a/src/frontend/frontend/console.js
+++ b/src/frontend/frontend/console.js
@@ -197,6 +197,10 @@ angular.module('frontend-app')
       if(res.result==="passed") {
         self.write('----------------------------------\n');
         self.write(sprintf("Test \"%s\" passed.\n", res.test_name));
+        if(!!res.stderr) {
+          self.write('Produced errors (stderr):\n');
+          self.write(res.stderr);
+        }
       }
       else if(res.result==="failed") {
         self.write('----------------------------------\n');


### PR DESCRIPTION
  * Show non-empty stderr from student program even if tests pass
 * Update ASAN parser to check for stack overflow caused by recursion, and report error type as stack-overflow instead of unknown