### PR TITLE
Fix seashell-cli delete-file error caused by multiple threads deleting the same file

### DIFF
--- a/src/collects/seashell/backend/dispatch.rkt
+++ b/src/collects/seashell/backend/dispatch.rkt
@@ -320,9 +320,14 @@
         ('tests test))
        (define-values (success? result)
          (compile-and-run-project/use-runner name question test))
+       ;; The front-end doesn't need/care about the thread.
+       (define result-without-thread
+         (if (hash? result)
+             (hash-remove result 'students-program-thread)
+             result))
        `#hash((id . ,id)
               (success . ,success?)
-              (result . ,result))]
+              (result . ,result-without-thread))]
       [(hash-table
          ('id id)
          ('type "startIO")

--- a/src/collects/seashell/backend/project.rkt
+++ b/src/collects/seashell/backend/project.rkt
@@ -457,15 +457,16 @@
                      (lambda (test)
                        (run-program target base project-base-str lang test real-test-location))
                      tests))
-      (thread
-        (lambda ()
-          (let loop ([evts (map program-wait-evt pids)])
-            (unless (empty? evts)
-              (loop (remove (apply sync evts) evts))))
-          (match lang
-            ['C (delete-directory/files target #:must-exist? #f)]
-            ['racket (delete-directory/files racket-temp-dir #:must-exist? #f)])))
-      (values #t `#hash((pids . ,pids) (messages . ,messages) (status . "running")))]
+      (define test-thread
+        (thread
+          (lambda ()
+            (let loop ([evts (map program-wait-evt pids)])
+              (unless (empty? evts)
+                (loop (remove (apply sync evts) evts))))
+            (match lang
+              ['C (delete-directory/files target #:must-exist? #f)]
+              ['racket (delete-directory/files racket-temp-dir #:must-exist? #f)]))))
+      (values #t `#hash((pids . ,pids) (messages . ,messages) (status . "running") (students-program-thread . ,test-thread)))]
     [else
       (values #f `#hash((messages . ,messages) (status . "compile-failed")))]))
 


### PR DESCRIPTION
Fixes a problem where seashell-cli marmtest sometimes crashes with the error "delete-file: cannot delete file" claiming that "system error: No such file or directory; errno=2"